### PR TITLE
Prevent docs from being uploaded from PR builds

### DIFF
--- a/.ci/docs.sh
+++ b/.ci/docs.sh
@@ -36,10 +36,10 @@ elif [[ "$COMMAND" == "upload" ]]; then
     if [[ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
         git commit -m "Documentation for release $TRAVIS_TAG"
         git push -q "https://$GH_TOKEN@github.com/nengo/{{ PROJECT }}.git" gh-pages-release
-    elif [[ "$TRAVIS_BRANCH" == "master" ]]; then
+    elif [[ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "master" ]]; then
         git commit -m "Last update at $(date '+%Y-%m-%d %T')"
         git push -fq "https://$GH_TOKEN@github.com/nengo/{{ PROJECT }}.git" gh-pages-release:gh-pages
-    else
+    elif [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         git commit -m "Documentation for branch $TRAVIS_BRANCH"
         git push -fq "https://$GH_TOKEN@github.com/nengo/{{ PROJECT }}.git" gh-pages-release:gh-pages-test
     fi


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

We check if `TRAVIS_BRANCH==master` in order to decide whether to update `gh-pages`.  However, there's a bit of a gotcha with Travis where PR builds will have `TRAVIS_BRANCH=master` (rather than the name of the PR branch).  This generally doesn't affect us, because we don't enable PR builds.  But in case these bones are used in a repo that does enable PR builds, this makes sure everything works smoothly.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Implemented these changes in NengoDL (which does have PR builds), and they work as advertised (e.g., note that https://travis-ci.org/nengo/nengo-dl/jobs/462924853 does not upload the docs).

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

