### PR TITLE
Static checks only delete .py files they created

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -42,6 +42,9 @@ ci_scripts:
   - template: static
     pre_commands:
       - cat .ci/static.sh
+    post_commands:
+      - "[ -f 'docs/examples/ignore-me.py' ]"
+      - "[ ! -f 'docs/examples/test-example.py' ]"
   - template: test
     pre_commands:
       - cat .ci/test.sh

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@ Release History
 - Added ``analytics_id`` option to ``docs_conf.py.template``,
   which will enable Google Analytics tracking. (`#35`_)
 
+**Fixed**
+
+- Fixed an issue with ``static.sh.template`` in which Python files
+  that were not converted from notebooks were deleted. (`#16`_)
+
+.. _#16: https://github.com/nengo/nengo-bones/pull/16
 .. _#35: https://github.com/nengo/nengo-bones/pull/35
 
 0.2.0 (May 15, 2019)

--- a/docs/examples/ignore-me.py
+++ b/docs/examples/ignore-me.py
@@ -1,0 +1,4 @@
+"""
+This file exists to test that we do not delete Python scripts in documentation
+except for those created by nbconvert.
+"""

--- a/nengo_bones/templates/static.sh.template
+++ b/nengo_bones/templates/static.sh.template
@@ -24,10 +24,18 @@ shopt -s globstar
     #   s/# $/#/g replaces lines with just '# ' with '#'
     #   /get_ipython()/d removes lines containing 'get_ipython()'
     #   $ d removes a trailing newline
-    sed -i -e 's/# $/#/g' -e '/get_ipython()/d' -e '$ d' -- docs/examples/**/*.py
+    for nb_file in docs/examples/**/*.ipynb; do
+        sed -i \
+            -e 's/# $/#/g' \
+            -e '/get_ipython()/d' \
+            -e '$ d' \
+            -- "${nb_file%.ipynb}.py"
+    done
     exe pylint docs --rcfile=setup.cfg --disable=missing-docstring,trailing-whitespace,wrong-import-position,unnecessary-semicolon
     exe flake8 docs --extend-ignore=E402,E703,W291,W293,W391
-    rm docs/examples/**/*.py
+    for nb_file in docs/examples/**/*.ipynb; do
+        rm "${nb_file%.ipynb}.py"
+    done
     exe codespell -q 3 \
         --skip="./build,./docs/_build,*-checkpoint.ipynb,./.eggs,./.git"
         {%- if codespell_ignore_words %} \
@@ -41,7 +49,9 @@ shopt -s globstar
     N_COMMITS=$(git rev-list --count HEAD ^origin/master)
     for ((i=0; i<N_COMMITS; i++)) do
         {# TODO: way to get this working properly with exe? #}
-        git log -n 1 --skip $i --pretty=%B | grep -v '^Co-authored-by:' | gitlint -vvv || STATUS=1
+        git log -n 1 --skip $i --pretty=%B \
+            | grep -v '^Co-authored-by:' \
+            | gitlint -vvv || STATUS=1
     done
     exe python setup.py checkdocs
 {% endblock %}


### PR DESCRIPTION
In checking the notebooks, we turn them into .py files. We now
only delete the .py files associated with notebooks, and not
other .py files that might be in the `docs/examples` directory.

**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

In nengo-loihi, we have other .py files in `docs/examples` that we should not delete.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Tried it out locally.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
