### PR TITLE
Add more visible failure message to shell scripts

### DIFF
--- a/nengo_bones/templates/base_script.sh.template
+++ b/nengo_bones/templates/base_script.sh.template
@@ -15,7 +15,7 @@ exe() {
     for i in "${!args[@]}"; do
       [ -n "${args[$i]}" ] || unset "args[$i]"
     done
-    "${args[@]}" || STATUS=1;
+    "${args[@]}" || { echo -e "\033[1;31mCOMMAND '${args[0]}' FAILED\033[0m"; STATUS=1; }
 }
 
 if [[ ! -e {{ pkg_name }} ]]; then


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

It can be hard to pick out failures when reading through a long log on e.g. TravisCI.  This makes them more obvious with an explicit failure message and a bright red colour.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added a test commit so you can see what a failure looks like here https://travis-ci.org/nengo/nengo-bones/jobs/533351613#L783

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.