### PR TITLE
Add some documents from nengo.ai

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,11 @@ Release History
 0.3.1 (unreleased)
 ==================
 
+**Added**
 
+- Added style guide and release instructions to documentation. (`#44`_)
+
+.. _#44: https://github.com/nengo/nengo-bones/pull/44
 
 0.3.0 (July 19, 2019)
 =====================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,5 +8,8 @@ Nengo Bones
     introduction
     cli
     examples
+    releasing
+    style
+    policies
     reference
     changes

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -1,0 +1,41 @@
+********
+Policies
+********
+
+Development of all Nengo projects
+happens on `Github <https://github.com/nengo>`_.
+For projects in the Nengo organization,
+we follow these policies.
+
+1. We require that all contributors sign the
+   `Nengo Contributor Assignment Agreement <https://www.nengo.ai/caa/>`_.
+
+2. We follow the
+   `semantic versioning specification <https://semver.org/>`_.
+
+Projects that have not yet been released
+are considered experimental,
+and the contributors to those projects
+are free to follow whatever practices
+they prefer prior to the initial public release.
+
+Once a project has had an initial public release,
+it is considered under active development,
+and follows these additional policies.
+
+3. We require that all changes,
+   even those made by the project maintainer,
+   be proposed as a pull request.
+
+4. We require that all pull requests be well tested.
+
+5. We require that each commit passes all unit tests,
+   including :doc:`style <style>` checks.
+
+6. We require that every pull request be reviewed
+   by at least one reviewer.
+
+7. We require that non-trivial pull requests include a changelog entry.
+
+8. We require that pull requests are merged by someone
+   other than the person making the pull request.

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -1,0 +1,162 @@
+***************
+Making releases
+***************
+
+These instructions assume that
+your project is using Nengo Bones
+to generate CI scripts,
+in particular the ``deploy.sh`` script.
+
+Python projects
+===============
+
+In the following steps, ``X.Y.Z`` is the new version number.
+
+1. Start a release candidate branch.
+
+   1. Switch to ``master`` and ensure it is up-to-date by doing ``git pull``.
+
+   2. Create a new branch off of ``master`` with
+
+      .. code-block:: bash
+
+         git checkout -b release-candidate-X.Y.Z
+
+2. Verify the repository is in a release-ready state.
+
+   The exact procedure will depend on the repository
+   and how many changes have occurred since the last release,
+   but may include the following steps.
+
+   1. Run all tests to ensure they pass on all supported platforms,
+      including slow tests that are normally skipped.
+      The command will depend on the repository,
+      but for Nengo core it's
+
+      .. code-block:: bash
+
+         pytest --pyargs nengo --plots --analytics --logs --slow
+
+   2. Review all of the outputs (e.g., plots)
+      generated from the test suite for abnormalities.
+
+   3. Build documentation and review it for abnormalities.
+
+   4. Commit all changes from the above steps with appropriate messages.
+
+3. Make a release commit.
+
+   1. Change the version information for your project.
+      For most Python projects, it lives in ``project/version.py``.
+      See that file for details.
+
+   2. Set the release date in the changelog, ``CHANGES.rst``.
+
+   3. Commit all changes from the above steps with
+
+      .. code-block:: bash
+
+         git commit -m "Release vX.Y.Z"
+
+4. Push the release candidate branch.
+
+   This will start a TravisCI build that will run several checks
+   to verify that the repository is in a good state for release.
+
+   1. If the build fails, fix any issues and commit the changes
+      such that they appear before the release commit in ``git log``.
+
+   2. When the TravisCI build succeeds,
+      inspect the release and associated metadata and files at,
+      e.g., https://test.pypi.org/project/nengo
+
+      In particular, make sure that extraneous files are not
+      included in the released files.
+      File sizes give a good indication of whether
+      extra files are present.
+
+      If there are any issues, fix them and commit them before
+      the release commit.
+
+   3. *Optional:*
+      Make a pull request on the release candidate branch
+      to solicit reviews.
+
+      This should be done if any non-trivial changes were made
+      in the previous steps, or if the release includes
+      many changes that should be verified on multiple machines.
+      Use your best judgment and consult with your team if unsure.
+
+5. Release to PyPI.
+
+   1. Tag the release commit with the version number; i.e.,
+
+      .. code-block:: bash
+
+         git tag -a vX.Y.Z
+
+      We use annotated tags to retain authorship information.
+      If you wish to provide a message with information about the release,
+      feel free, but it is not necessary.
+
+   2. Push the tag with
+
+      .. code-block:: bash
+
+         git push origin vX.Y.Z
+
+      Pushing the tag will trigger another TravisCI build
+      that will deploy the release and updated documentation.
+
+   3. Confirm the release has been done successfully
+      at, e.g., https://pypi.org/project/nengo
+      once the TravisCI build is complete.
+
+6. Start the next version.
+
+   1. Change the version information in ``project/version.py``.
+
+   2. Make a new changelog section in ``CHANGES.rst``
+      in order to collect changes for the next release.
+
+   3. ``git add`` the changes above and commit with
+
+      .. code-block:: bash
+
+         git commit -m "Starting development of vX.Y.Z+1"
+
+   4. *Optional:*
+      If you opened a PR on the release candidate branch,
+      push it to Github so it will be marked as merged.
+
+   5. Merge the release candidate branch into ``master``
+      and push the ``master`` branch.
+
+   6. Delete the release candidate branch locally and remotely.
+
+7. Announce the new release.
+
+   1. Copy the changelog into the tag details on the
+      Github release tab.
+      Note that the changelog is in reStructuredText,
+      while Github expects Markdown.
+      Use `Pandoc <https://pandoc.org/try/>`_
+      to convert between the two formats
+      with the following command:
+
+      .. code-block:: bash
+
+         pandoc -t gfm -f rst CHANGES.rst
+
+   2. Write a release announcement.
+      Generally, it's easiest to start from
+      the last release announcement
+      and change it to make sense with the current release
+      so that the overall template of each announcement is similar.
+      Post the release announcement on the
+      `forum <https://forum.nengo.ai/c/general/announcements>`_.
+
+   3. Make a PR on the
+      `ABR website repo <https://github.com/abr/abr.github.io>`__
+      modifying a file in the ``_releases`` folder to
+      point to the announcement post on the forum.

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -1,0 +1,96 @@
+***********
+Style guide
+***********
+
+Nengo Bones attempts to enforce
+as much of this style guide as possible.
+However, since not everything can be automatically enforced,
+all Nengo developers should be familiar with this style guide
+and follow it when working on Nengo projects.
+
+Python
+======
+
+We use ``flake8`` and ``pylint`` for automated checks.
+The exact options may vary from project to project,
+so the easiest way to run these checks is to
+run the ``.ci/static.sh`` script locally.
+
+.. code-block:: bash
+
+   bones-generate --output-dir .ci ci-scripts && .ci/static.sh script
+
+If you are missing any required packages,
+running ``.ci/static.sh install`` should install all requirements.
+
+Class member order
+------------------
+
+In general, we stick to the following order for members of Python classes.
+
+1. Class-level member variables (e.g., ``nengo.Ensemble.probeable``).
+2. Parameters (i.e., instances of ``nengo.params.Parameter``)
+   with the parameters in ``__init__`` going first in that order,
+   then parameters that don't appear in ``__init__`` in alphabetical order.
+   All these parameters should appear in the Parameters section of the docstring
+   in the same order.
+3. ``__init__``
+4. Other special (``__x__``) methods in alphabetical order,
+   except when a grouping is more natural
+   (e.g., ``__getstate__`` and ``__setstate__``).
+5. ``@property`` properties in alphabetical order.
+6. ``@staticmethod`` methods in alphabetical order.
+7. ``@classmethod`` methods in alphabetical order.
+8. Methods in alphabetical order.
+
+"Hidden" versions of the above (i.e., anything starting with an underscore)
+should either be placed right after they're first used,
+or at the end of the class.
+
+.. note:: These are guidelines that should be used in general,
+          not strict rules.
+          If there is a good reason to group differently,
+          then feel free to do so, but please explain
+          your reasoning in a code comment or commit message.
+
+Docstrings
+----------
+
+We use ``numpydoc`` and
+`NumPy's guidelines for docstrings
+<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_,
+as they are readable in plain text and when rendered with Sphinx.
+
+We use the default role of ``obj`` in documentation,
+so any strings placed in backticks in docstrings
+will be cross-referenced properly if they
+unambiguously refer to something in the Nengo documentation.
+See `Cross-referencing syntax
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-syntax>`_
+and the `Python domain
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#the-python-domain>`_
+for more information.
+
+Git
+===
+
+We use several advanced ``git`` features that
+rely on well-formed commit messages.
+Commit messages should fit the following template.
+
+.. code-block:: none
+
+   Capitalized, short (50 chars or less) summary
+
+   More detailed body text, if necessary.  Wrap it to around 72 characters.
+   The blank line separating the summary from the body is critical.
+
+   Paragraphs must be separated by a blank line.
+
+   - Bullet points are okay, too.
+   - Typically a hyphen or asterisk is used for the bullet, followed by
+     single space, with blank lines before and after the list.
+   - Use a hanging indent if the bullet point is longer than a
+     single line (like in this point).
+
+.. todo:: JS, TS, CSS, HTML, etc


### PR DESCRIPTION
**Motivation and context:**

While doing the nengo.ai redesign, it made sense to move some of the items in the "contributor guide" here. Specifically, this PR adds:

- list of dev policies
- style guide
- release instructions for Python projects

These documents are now more or less tied to the Nengo Bones project, so it will be easier to keep them up to date in this repository.

Other elements of the contributor guide will remain on nengo.ai:

- a "how to contribute" page
- the Nengo code of conduct
- the Nengo contributor assignment agreement

And one page will be removed entirely as it is out of date and not worth redoing:

- Reviewer guide

**How has this been tested?**

Built the docs locally and verified that pages render as expected.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [na] I have run the test suite locally and all tests passed.

**Still to do:**

Note that this PR links to the CAA, so we should wait until the nengo.ai redesign is done and make sure the link ends up being correct before merging.