### PR TITLE
Disable static checks conflicting with Black

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,9 +35,12 @@ Release History
 - Templates will now be autoformatted with Black during the rendering
   process, if Black is installed. (`#49`_)
 - Take advantage of multiprocessing to speed up pylint static checks. (`#49`_)
+- The ``E203`` flake8 check and ``bad-continuation`` pylint check are now
+  disabled by default. (`#50`_)
 
 .. _#44: https://github.com/nengo/nengo-bones/pull/44
 .. _#49: https://github.com/nengo/nengo-bones/pull/49
+.. _#50: https://github.com/nengo/nengo-bones/pull/50
 
 0.3.0 (July 19, 2019)
 =====================

--- a/nengo_bones/templates/setup.cfg.template
+++ b/nengo_bones/templates/setup.cfg.template
@@ -41,6 +41,7 @@ exclude =
 ignore =
     E123
     E133
+    E203
     E226
     E241
     E242
@@ -102,6 +103,7 @@ disable =
     arguments-differ,
     assignment-from-no-return,
     attribute-defined-outside-init,
+    bad-continuation,
     blacklisted-name,
     comparison-with-callable,
     duplicate-code,

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ exclude =
 ignore =
     E123
     E133
+    E203
     E226
     E241
     E242
@@ -70,6 +71,7 @@ disable =
     arguments-differ,
     assignment-from-no-return,
     attribute-defined-outside-init,
+    bad-continuation,
     blacklisted-name,
     comparison-with-callable,
     duplicate-code,


### PR DESCRIPTION
**Motivation and context:**
Black adds space before colons and the pylint bad-continuation check gives false positives for a situation that commonly occurs with Black; see https://github.com/PyCQA/pylint/issues/289

The changelog entry is not super necessary, but I figured it would be a good reminder to us to remove these disables if they're done in downstream repos.

**How has this been tested?**
Ran `black` and confirmed that static checks pass on downstream repos with these additional disables.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
