### PR TITLE
Add pydocstyle to static checks

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -100,9 +100,9 @@ manifest_in: {}
 setup_py:
   entry_points:
     console_scripts:
-      - bones-generate=nengo_bones.scripts.generate_bones:main
-      - bones-check=nengo_bones.scripts.check_bones:main
-      - bones-pr-number=nengo_bones.scripts.pr_number:main
+      - bones-generate = nengo_bones.scripts.generate_bones:main
+      - bones-check = nengo_bones.scripts.check_bones:main
+      - bones-pr-number = nengo_bones.scripts.pr_number:main
   include_package_data: True
   # note: docs/tests_req are intentionally empty to test that the correct
   # requirements are built into the ci scripts
@@ -150,6 +150,7 @@ setup_cfg:
   pylint:
     ignore:
       - nengo_bones/tests/ignoreme
+
 
 docs_conf_py:
   exclude_patterns:

--- a/nengo_bones/config.py
+++ b/nengo_bones/config.py
@@ -8,8 +8,7 @@ import yaml
 
 
 def check_list(cfg, key):
-    """
-    Verify that config value is a list.
+    """Verify that config value is a list.
 
     This is designed to catch the common error of specifying
 
@@ -45,8 +44,7 @@ def check_list(cfg, key):
 
 
 def find_config():
-    """
-    Finds the default nengo-bones config file.
+    """Find the default nengo-bones config file.
 
     Returns
     -------
@@ -60,8 +58,7 @@ def find_config():
 
 
 def fill_defaults(config):
-    """
-    Fills in default values in a loaded config (in-place).
+    """Fill in default values in a loaded config (in-place).
 
     Parameters
     ----------
@@ -127,8 +124,7 @@ def fill_defaults(config):
 
 
 def validate_black_config(config):
-    """
-    Validates aspects of the config related to Black.
+    """Validate aspects of the config related to Black.
 
     Parameters
     ----------
@@ -157,8 +153,7 @@ def validate_black_config(config):
 
 
 def validate_setup_cfg_config(config):
-    """
-    Validates the ``setup_cfg`` section of the config.
+    """Validate the ``setup_cfg`` section of the config.
 
     Parameters
     ----------
@@ -176,8 +171,7 @@ def validate_setup_cfg_config(config):
 
 
 def validate_config(config):  # noqa: C901
-    """
-    Validates a populated config dict.
+    """Validate a populated config dict.
 
     Parameters
     ----------
@@ -209,8 +203,7 @@ def validate_config(config):  # noqa: C901
 
 
 def validate_ci_config(ci_config):
-    """
-    Validates an entry in the ci_scripts list of a config dict.
+    """Validate an entry in the ci_scripts list of a config dict.
 
     Parameters
     ----------
@@ -237,8 +230,7 @@ def validate_ci_config(ci_config):
 
 
 def load_config(conf_file=None):
-    """
-    Loads config values from a file and applies defaults/validation.
+    """Load config values from a file and apply defaults/validation.
 
     Parameters
     ----------

--- a/nengo_bones/scripts/check_bones.py
+++ b/nengo_bones/scripts/check_bones.py
@@ -20,8 +20,7 @@ from nengo_bones.templates import BonesTemplate, load_env
     "--verbose", is_flag=True, help="Show more information about failed checks."
 )
 def main(root_dir, conf_file, verbose):
-    """
-    Validates auto-generated project files.
+    """Validate auto-generated project files.
 
     Note: This does not check the ci scripts, because those are generated
     on-the-fly in TravisCI (so any ci files we do find are likely local

--- a/nengo_bones/scripts/generate_bones.py
+++ b/nengo_bones/scripts/generate_bones.py
@@ -10,8 +10,7 @@ from nengo_bones.templates import BonesTemplate, load_env
 
 
 def render_template(ctx, output_file):
-    """
-    Render a template to file.
+    """Render a template to file.
 
     Parameters
     ----------
@@ -33,7 +32,7 @@ def render_template(ctx, output_file):
 @click.option("--output-dir", default=".", help="Output directory for scripts")
 @click.pass_context
 def main(ctx, conf_file, output_dir):
-    """Loads config file and sets up template environment.
+    """Load config file and set up template environment.
 
     By default, this updates all templated files that are
     to be committed to the repository.

--- a/nengo_bones/templates.py
+++ b/nengo_bones/templates.py
@@ -15,8 +15,7 @@ import jinja2
 
 
 class BonesTemplate:
-    """
-    A templated file known to Nengo Bones.
+    """A templated file known to Nengo Bones.
 
     The only necessary information is the output filename, relative to the
     ``templates`` directory, which means that the output filename for the
@@ -60,8 +59,7 @@ class BonesTemplate:
         self.template_file = "%s.template" % (output_file,)
 
     def get_render_data(self, config):
-        """
-        Construct the ``data`` that will be used to render this template.
+        """Construct the ``data`` that will be used to render this template.
 
         This method creates a new dictionary so the original ``config``
         is not modified. Additionally, certain sections have
@@ -116,8 +114,7 @@ class BonesTemplate:
         return data
 
     def render(self, **data):
-        """
-        Render this template to a string.
+        """Render this template to a string.
 
         Parameters
         ----------
@@ -145,8 +142,7 @@ class BonesTemplate:
         return rendered
 
     def render_to_file(self, output_dir, output_name=None, **data):
-        """
-        Render a template to file.
+        """Render a template to file.
 
         .. note:: Rendered shell scripts (files with the ``.sh extension``)
                   are automatically marked as executable.
@@ -178,7 +174,7 @@ class BonesTemplate:
 
 
 def load_env():
-    """Creates a jinja environment for loading/rendering templates."""
+    """Create a jinja environment for loading/rendering templates."""
 
     bones_toplevel = os.path.normpath(os.path.dirname(__file__))
 

--- a/nengo_bones/templates/setup.cfg.template
+++ b/nengo_bones/templates/setup.cfg.template
@@ -115,10 +115,28 @@ plt_filename_drop =
 {% endif %}
 {% endblock %}
 
+{% block pydocstyle %}
+[pydocstyle]
+ignore =
+    D10,
+    D202,
+    D203,
+    D213,
+    D401,
+    D402,
+    D405,
+    D413,
+    D415,
+    D416,
+match-dir = '[^\._].*'
+{% endblock %}
+
 {% block pylint %}
 [pylint]
 # note: pylint doesn't look in setup.cfg by default, need to call it with
 # `pylint ... --rcfile=setup.cfg`
+# Also, this needs to be the last section in this file, so any additional
+# configuration must be added above here.
 {% if pylint.ignore %}
 ignore =
     {% for ignore in pylint.ignore %}

--- a/nengo_bones/templates/static.sh.template
+++ b/nengo_bones/templates/static.sh.template
@@ -8,12 +8,13 @@ shopt -s globstar
 
 {% block install %}
 {{ super() }}
-    exe pip install "jupyter>=1.0.0" "pylint>=1.9.2" "codespell>=1.12.0" "gitlint>=0.1.2" "collective.checkdocs>=0.2" "flake8>=3.7.7"
+    exe pip install "jupyter>=1.0.0" "pylint>=1.9.2" "codespell>=1.12.0" "gitlint>=0.1.2" "collective.checkdocs>=0.2" "flake8>=3.7.7" "pydocstyle>=4.0.0"
 {% endblock %}
 
 {% block script %}
     exe pylint {{ pkg_name }} --rcfile=setup.cfg --jobs=0
     exe flake8 {{ pkg_name }}
+    exe pydocstyle {{ pkg_name }}
     if ls docs/**/*.ipynb &>/dev/null; then
         exe jupyter nbconvert \
             --log-level WARN \

--- a/nengo_bones/tests/utils.py
+++ b/nengo_bones/tests/utils.py
@@ -5,7 +5,7 @@ from traceback import print_tb
 
 
 def write_file(tmpdir, filename, contents):
-    """Writes a (multiline) string to file."""
+    """Write a (multiline) string to file."""
 
     contents = contents.splitlines()
 
@@ -37,7 +37,7 @@ def assert_exit(result, status):
 
 
 def make_has_line(lines, strip=False, regex=False):
-    """Create a function to check file or output lines in order"""
+    """Create a function to check file or output lines in order."""
 
     idx = 0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,9 +62,25 @@ nengo_test_unsupported =
     *
         "All tests are unsupported"
 
+[pydocstyle]
+ignore =
+    D10,
+    D202,
+    D203,
+    D213,
+    D401,
+    D402,
+    D405,
+    D413,
+    D415,
+    D416,
+match-dir = '[^\._].*'
+
 [pylint]
 # note: pylint doesn't look in setup.cfg by default, need to call it with
 # `pylint ... --rcfile=setup.cfg`
+# Also, this needs to be the last section in this file, so any additional
+# configuration must be added above here.
 ignore =
     nengo_bones/tests/ignoreme,
 disable =

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ setup(
     python_requires=">=3.5",
     entry_points={
         "console_scripts": [
-            "bones-generate=nengo_bones.scripts.generate_bones:main",
-            "bones-check=nengo_bones.scripts.check_bones:main",
-            "bones-pr-number=nengo_bones.scripts.pr_number:main",
+            "bones-generate = nengo_bones.scripts.generate_bones:main",
+            "bones-check = nengo_bones.scripts.check_bones:main",
+            "bones-pr-number = nengo_bones.scripts.pr_number:main",
         ]
     },
     classifiers=[


### PR DESCRIPTION
**Motivation and context:**
When verifying https://github.com/nengo/nengo/pull/1557, it seemed easier to just enable the checks that were being implemented there than do manual verification that all instances of the issues were fixed. And if we feel like they're worth making a Nengo PR for, we might as well add those checks to Nengo Bones so that we don't add more docstrings that would fail those checks.

That said, this PR likely needs some discussion; see the todo section at the bottom.

**How has this been tested?**
Applied to Nengo Bones.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [ ] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.

**Still to do:**

- [ ] Come to consensus on what checks we want to add / ignore (most notably `D401`, see the squash commit in this PR)
- [ ] Add documentation
- [ ] Add changelog entry