### PR TITLE
Add doctest support to docs

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -166,6 +166,9 @@ docs_conf_py:
   intersphinx_mapping:
     click: https://click.palletsprojects.com/en/7.x
   analytics_id: UA-41658423-2
+  doctest_setup:
+    - "# Testing that doctest_setup works"
+    - "# with multiple lines"
 
 pre_commit_config_yaml:
   exclude:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
       exclude: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,9 +19,14 @@ Release History
    - Removed
    - Fixed
 
-0.6.1 (unreleased)
+0.7.0 (unreleased)
 ==================
 
+**Changed**
+
+- Updated the ``black`` version used in ``pre-commit`` hooks. (`#67`_)
+
+.. _#67: https://github.com/nengo/nengo-bones/pull/67
 
 0.6.0 (October 30, 2019)
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 0.7.0 (unreleased)
 ==================
 
+**Added**
+
+- Added support for ``sphinx.ext.doctest``, which can be used to automatically
+  test code snippets in docstrings. (`#67`_)
+
 **Changed**
 
 - Updated the ``black`` version used in ``pre-commit`` hooks. (`#67`_)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import nengo_bones
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
@@ -24,6 +25,13 @@ extensions = [
 autoclass_content = "both"  # class and __init__ docstrings are concatenated
 autodoc_default_options = {"members": None}
 autodoc_member_order = "bysource"  # default is alphabetical
+
+# -- sphinx.ext.doctest
+doctest_global_setup = """
+import nengo_bones
+# Testing that doctest_setup works
+# with multiple lines
+"""
 
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {

--- a/docs/examples/configuration.ipynb
+++ b/docs/examples/configuration.ipynb
@@ -1644,6 +1644,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `doctest_setup` config option contains a list of Python statements\n",
+    "that should be executed before the code in `.. testcode::` blocks,\n",
+    "which are run with the `sphinx.ext.doctest` extension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nengobones_yml = \"\"\"\n",
+    "docs_conf_py:\n",
+    "    doctest_setup:\n",
+    "        - import nengo\n",
+    "\"\"\"\n",
+    "write_yml(nengobones_yml)\n",
+    "\n",
+    "!bones-generate docs-conf-py\n",
+    "display_contents(\"docs/conf.py\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Finally, the `sphinx_options` config option can be used to set\n",
     "arbitrary options of the form `var = val` in the conf.py file."
    ]

--- a/nengo_bones/templates.py
+++ b/nengo_bones/templates.py
@@ -62,7 +62,19 @@ class BonesTemplate:
 
     @classmethod
     def add_render_data(cls, filename):
-        """Register functions that add template-specific render data."""
+        """
+        Register functions that add template-specific render data.
+
+        For example:
+
+        .. testcode::
+
+           @nengo_bones.templates.BonesTemplate.add_render_data("my_new_template")
+           def add_my_new_template_data(data):
+               data["attr"] = "val"
+               ...
+
+        """
 
         def _add_render_data(func):
             cls.extra_render_data[filename].append(func)

--- a/nengo_bones/templates/.pre-commit-config.yaml.template
+++ b/nengo_bones/templates/.pre-commit-config.yaml.template
@@ -2,7 +2,7 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
       {% if exclude %}

--- a/nengo_bones/templates/docs.sh.template
+++ b/nengo_bones/templates/docs.sh.template
@@ -27,6 +27,7 @@
     export DOCS_STATUS="$STATUS"
 
     exe sphinx-build -b linkcheck -vW -D nbsphinx_execute=never docs docs/_build
+    exe sphinx-build -b doctest -vW -D nbsphinx_execute=never docs docs/_build
 {% endblock %}
 
 {% block after_script %}

--- a/nengo_bones/templates/docs/conf.py.template
+++ b/nengo_bones/templates/docs/conf.py.template
@@ -9,6 +9,7 @@ import {{ pkg_name }}
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
@@ -26,6 +27,14 @@ extensions = [
 autoclass_content = "both"  # class and __init__ docstrings are concatenated
 autodoc_default_options = {"members": None}
 autodoc_member_order = "bysource"  # default is alphabetical
+
+# -- sphinx.ext.doctest
+doctest_global_setup = """
+import {{ pkg_name }}
+{% for line in doctest_setup %}
+{{ line }}
+{% endfor %}
+"""
 
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -14,7 +14,7 @@ version numbers as follows:
 """
 
 name = "nengo-bones"
-version_info = (0, 6, 1)  # (major, minor, patch)
+version_info = (0, 7, 0)  # (major, minor, patch)
 dev = 0
 
 version = "{v}{dev}".format(


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

This allows us to automatically test code snippets in docstrings during CI. Note that downstream repos still need to opt in to this by changing ``.. code-block:: python`` directives to ``.. testcode::``.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added one testable code snippet to nengo-bones docs, and I will check that this works in nengo-dl (which already uses `doctest`).

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
- [x] Test with NengoDL