### PR TITLE
Add a lock to the remote script cleanup block

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,13 @@ Release History
 - Added support for ``nengo_sphinx_theme.ext.redirects``, which can be used to
   automatically add redirects for renamed documentation pages. (`#68`_)
 
+**Fixed**
+
+- Added locking to ``remote.sh`` script to avoid possible race conditions
+  during cleanup. (`#69`_)
+
 .. _#68: https://github.com/nengo/nengo-bones/pull/68
+.. _#69: https://github.com/nengo/nengo-bones/pull/69
 
 0.7.0 (November 7, 2019)
 ========================

--- a/nengo_bones/templates/remote.sh.template
+++ b/nengo_bones/templates/remote.sh.template
@@ -103,10 +103,15 @@ EOF
     eval "bash <(curl -s https://codecov.io/bash)"
     {% endif %}
     exe ssh {{ host }} -q << EOF
-        {% block remote_cleanup %}
         echo "$ ({{ host }}) Cleaning up {{ pkg }}"
         cd ~/tmp
-        ls -tp | grep '{{ pkg }}-' | tail -n +3 | xargs -I {} rm -r -- {}
-        {% endblock %}
+        (
+          flock -x -w 540 200 || exit 1
+          echo "$ Obtained cleanup lock"
+          {% block remote_cleanup %}
+          ls -tp | grep '{{ pkg }}-' | tail -n +3 | xargs -I {} rm -r -- {}
+          {% endblock %}
+        ) 200>cleanup.lock
+        exit \$?
 EOF
 {% endblock %}


### PR DESCRIPTION
**Motivation and context:**
In Nengo Loihi's CI testing, the remote script will occasionally fail when cleaning up the `~/tmp` directory. This might be because the script is being run concurrently by two TravisCI processes. Normally that's fine because each job touches unique files, but that's not the case when cleaning up the `~/tmp` directory.

This PR adds a lock so that only one process at a time can clean up the `~/tmp` directory. The second process will immediately exit with a successful error code so that we don't wait indefinitely.

The downside of succeeding immediately is that if a process gets stuck or cancelled during the cleanup block, it might be possible that the lock file sticks around and we stop cleaning things up. To handle that, before obtaining the lock, I first see if the lock file is a day or more old. If that's the case, then it's very likely to be stale, so I remove it before obtaining the lock.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
It's hard to test that this works properly. I tried to acquire the lock and rerun the remote job, thinking that it would not be able to acquire the lock, but it was still able to acquire it. So I'm not sure if `flock` is working incorrectly? Maybe we should implement the lock manually, by making the `cleanup.lock` file if it doesn't exist and removing it after the cleanup is done?