### PR TITLE
Fix cleanup lock by not invoking subshell

### DIFF
--- a/nengo_bones/templates/remote.sh.template
+++ b/nengo_bones/templates/remote.sh.template
@@ -105,13 +105,12 @@ EOF
     exe ssh {{ host }} -q << EOF
         echo "$ ({{ host }}) Cleaning up {{ pkg }}"
         cd ~/tmp
-        (
-          flock -x -w 540 200 || exit 1
-          echo "$ Obtained cleanup lock"
-          {% block remote_cleanup %}
-          ls -tp | grep '{{ pkg }}-' | tail -n +3 | xargs -I {} rm -r -- {}
-          {% endblock %}
-        ) 200>cleanup.lock
-        exit \$?
+        exec 200>cleanup.lock || exit 1
+        flock --wait 540 200 || exit 1
+        echo "$ Obtained cleanup lock"
+        {% block remote_cleanup %}
+        ls -tp | grep '{{ pkg }}-' | tail -n +3 | xargs -I {} rm -r -- {}
+        {% endblock %}
+        flock --unlock 200
 EOF
 {% endblock %}


### PR DESCRIPTION
**Motivation and context:**

There seem to be issues when invoking a subshell in an SSH command in some environments, resulting in Travis CI failing with

```
wait: pid <pid> is not a child of this shell
```

The sequence of `flock` commands used in this commit should be equivalent to the subshell version, but it does not use a subshell.

See [this NengoDL job](https://travis-ci.org/nengo/nengo-dl/jobs/612476553#L1157)

**How has this been tested?**
Not heavily tested yet, we should have NengoDL use this branch and see if the issue is fixed.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
