### PR TITLE
Don't error if miniconda installation fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release History
 0.7.2 (unreleased)
 ==================
 
+**Changed**
+
+- Failing to install miniconda in ``remote.sh`` is no longer considered a build
+  error (this can occur, for example, when rerunning a build that already has
+  miniconda installed). (`#71`_)
+
+.. _#71: https://github.com/nengo/nengo-bones/pull/71
 
 0.7.1 (November 14, 2019)
 =========================

--- a/nengo_bones/templates/remote.sh.template
+++ b/nengo_bones/templates/remote.sh.template
@@ -82,7 +82,7 @@ See https://docs.travis-ci.com/user/encrypting-files/ for more details.
         {% block remote_install %}
         echo "$ ({{ host }}) Installing miniconda"
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --quiet -O miniconda.sh
-        bash miniconda.sh -b -p ./miniconda || REMOTE_STATUS=1
+        bash miniconda.sh -b -p ./miniconda
         export PATH="\$PWD/miniconda/bin:\$PATH"
         conda create -y -n travis-ci-"$TRAVIS_JOB_NUMBER" python="$TRAVIS_PYTHON_VERSION" || REMOTE_STATUS=1
         source activate travis-ci-"$TRAVIS_JOB_NUMBER" || REMOTE_STATUS=1


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

When rerunning a remote build, the miniconda installation may fail (because miniconda is already installed).  This isn't a fatal error (since miniconda is already installed), so this modifies the script to not mark the build as a failure if the miniconda installation fails.  If the miniconda installation were actually broken then we'd get an error in the environment creation step immediately after, which is still marked as an error.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Reran the remote build, confirmed it passed.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.