### PR TITLE
Remove coverage.py early starting logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ env:
   global:
     - SCRIPT="test"
     - TEST_ARGS=""
-    - COV_CORE_SOURCE=nengo_bones  # early start pytest-cov engine
-    - COV_CORE_CONFIG=.coveragerc
-    - COV_CORE_DATAFILE=.coverage.eager
     - BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
     - TEST_GLOBAL_VAR="test global var val"
     - TEST_LOCAL_VAR="this val will be overwritten"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,12 @@ Release History
 0.7.3 (unreleased)
 ==================
 
+**Removed**
 
+- Removed coverage.py early starting logic. This is no longer necessary as of Nengo
+  3.0 and causes problems with the new coverage.py 5.0 release. (`#78`_)
+
+.. _#78: https://github.com/nengo/nengo-bones/pull/78
 
 0.7.2 (December 2, 2019)
 ========================

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 Nengo Bones license
 *******************
 
-Copyright (c) 2018-2019 Applied Brain Research
+Copyright (c) 2018-2020 Applied Brain Research
 
 Nengo Bones is made available under a proprietary license
 that permits using, copying, sharing, and making derivative works from

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ suppress_warnings = ["image.nonlocal_uri"]
 
 project = "Nengo Bones"
 authors = "Applied Brain Research"
-copyright = "2018-2019 Applied Brain Research"
+copyright = "2018-2020 Applied Brain Research"
 version = ".".join(nengo_bones.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_bones.__version__  # Full version, with tags
 

--- a/nengo_bones/__init__.py
+++ b/nengo_bones/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring
 
-__copyright__ = "2018-2019, Applied Brain Research"
+__copyright__ = "2018-2020, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"
 
 from .version import version as __version__

--- a/nengo_bones/templates/.travis.yml.template
+++ b/nengo_bones/templates/.travis.yml.template
@@ -14,9 +14,6 @@ env:
   global:
     - SCRIPT="test"
     - TEST_ARGS=""
-    - COV_CORE_SOURCE={{ pkg_name }}  # early start pytest-cov engine
-    - COV_CORE_CONFIG=.coveragerc
-    - COV_CORE_DATAFILE=.coverage.eager
     - BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
     {% for var, val in global_vars.items() %}
     - {{ var|upper }}="{{ val }}"

--- a/nengo_bones/templates/test.sh.template
+++ b/nengo_bones/templates/test.sh.template
@@ -13,7 +13,7 @@
 
 {% block script %}
     # shellcheck disable=SC2086
-    exe pytest {{ pkg_name }} -v -n 2 --color=yes --durations 20 {%- if coverage %} --cov={{ pkg_name }} --cov-append --cov-report=term-missing {%- endif %} $TEST_ARGS
+    exe pytest {{ pkg_name }} -v -n 2 --color=yes --durations 20 {%- if coverage %} --cov={{ pkg_name }} --cov-report=term-missing {%- endif %} $TEST_ARGS
 
     {% if nengo_tests %}
     # shellcheck disable=SC2086

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -83,13 +83,13 @@ def test_ci_scripts(tmpdir):
     assert has_line(".ci/test.sh", "--durations 20 $TEST_ARGS", startswith=False)
     assert not has_line(
         ".ci/test.sh",
-        "--cov=dummy --cov-append --cov-report=term-missing $TEST_ARGS",
+        "--cov=dummy --cov-report=term-missing $TEST_ARGS",
         startswith=False,
     )
 
     assert has_line(
         ".ci/test-coverage.sh",
-        "--cov=dummy --cov-append --cov-report=term-missing $TEST_ARGS",
+        "--cov=dummy --cov-report=term-missing $TEST_ARGS",
         startswith=False,
     )
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

We were using an odd approach to try to early-start the coverage engine to help work around the issues caused by Nengo being imported before coverage data starts being collected.  However, this causes some issues in the new coverage.py 5.0 release (related to this issue https://github.com/nedbat/coveragepy/issues/883).  Fortunately, since we reworked the way Nengo's pytest infrastructure works in Nengo 3.0 this is no longer necessary, so I just removed it rather than trying to fix it.

Note that this may mean that coverage is not collected correctly when testing against Nengo<3.0. However, as long as those jobs are being combined with some coverage jobs running in Nengo>=3.0, I believe the overall coverage information should still be correct.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Ran into this in https://github.com/nengo/nengo/pull/1591, so I will check that the problem is solved there. I'll also check nengo-dl and nengo-loihi, to make sure that the coverage is still correct there after removing this logic.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.