### PR TITLE
Don't upload docs from broken builds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,8 +34,11 @@ Release History
 - Will now use ``nengo-bones`` and ``nengo-sphinx-theme`` master builds (instead of the
   latest release), to streamline the process of distributing changes to those core
   repos. (`#97`_)
+- Rendered documentation will not be uploaded if the html build fails (it will still
+  be uploaded if the linkchecker/doctest builds fail). (`#98`_)
 
 .. _#97: https://github.com/nengo/nengo-bones/pull/97
+.. _#98: https://github.com/nengo/nengo-bones/pull/98
 
 0.10.0 (March 19, 2020)
 =======================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Release History
   repos. (`#97`_)
 - Rendered documentation will not be uploaded if the html build fails (it will still
   be uploaded if the linkchecker/doctest builds fail). (`#98`_)
+- Rendered documentation will not be uploaded on cron builds. (`#98`_)
 
 .. _#97: https://github.com/nengo/nengo-bones/pull/97
 .. _#98: https://github.com/nengo/nengo-bones/pull/98

--- a/nengo_bones/templates/docs.sh.template
+++ b/nengo_bones/templates/docs.sh.template
@@ -42,6 +42,11 @@
         exit 1
     fi
 
+    if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+        echo "Skipping docs upload because this is a cron build"
+        exit 0
+    fi
+
     cd {{ docs_dir }} || exit
     git config --global user.email "info@appliedbrainresearch.com"
     git config --global user.name "Nengo Bones"

--- a/nengo_bones/templates/docs.sh.template
+++ b/nengo_bones/templates/docs.sh.template
@@ -17,23 +17,29 @@
     exe git clone -b gh-pages-release https://github.com/{{ repo_name }}.git {{ docs_dir }}
     RELEASES=$(find {{ docs_dir }} -maxdepth 1 -type d -name "v[0-9].*" -printf "%f,")
 
+    FAILED_FILE="$TRAVIS_JOB_NUMBER.failed"
+    rm -f "$FAILED_FILE"
     if [[ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
         RELEASES="$RELEASES$TRAVIS_TAG"
-        exe sphinx-build -b html docs {{ docs_dir }}/"$TRAVIS_TAG" -vW -A building_version="$TRAVIS_TAG" -A releases="$RELEASES"
+        sphinx-build -b html docs {{ docs_dir }}/"$TRAVIS_TAG" -vW --keep-going -A building_version="$TRAVIS_TAG" -A releases="$RELEASES" || touch "$FAILED_FILE"
     else
-        exe sphinx-build -b html docs {{ docs_dir }} -vW -A building_version=latest -A releases="$RELEASES"
+        sphinx-build -b html docs {{ docs_dir }} -vW --keep-going -A building_version=latest -A releases="$RELEASES" || touch "$FAILED_FILE"
     fi
 
-    export DOCS_STATUS="$STATUS"
+    if [[ -e "$FAILED_FILE" ]]; then
+        echo -e "\033[1;31mCOMMAND 'sphinx-build' FAILED\033[0m"
+        STATUS=1
+    fi
 
     exe sphinx-build -b linkcheck -vW -D nbsphinx_execute=never docs docs/_build
     exe sphinx-build -b doctest -vW -D nbsphinx_execute=never docs docs/_build
 {% endblock %}
 
 {% block after_script %}
-    if [[ "$DOCS_STATUS" -ne "0" ]]; then
+    FAILED_FILE="$TRAVIS_JOB_NUMBER.failed"
+    if [[ -e "$FAILED_FILE" ]]; then
         echo "Skipping docs upload because build failed"
-        exit "$DOCS_STATUS"
+        exit 1
     fi
 
     cd {{ docs_dir }} || exit


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

We still want to upload docs if the linkchecker or doctest builds fail, but this avoids uploading the documentation if the html build fails. Also avoids uploading documentation from cron builds, regardless of success or failure.

Fixes #62 

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Tested in the doc builds of this PR, see https://travis-ci.org/github/nengo/nengo-bones/jobs/672178467#L1036 and https://travis-ci.org/github/nengo/nengo-bones/jobs/672184876#L1002 

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [x] test doc failures