### PR TITLE
Switch to calendar versioning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,22 @@ Release History
    - Removed
    - Fixed
 
-0.11.0 (unreleased)
-===================
+0.11.1 (April 13, 2020)
+=======================
+
+**Changed**
+
+- Rendered documentation will not be uploaded if the html build fails (it will still
+  be uploaded if the linkchecker/doctest builds fail). (`#98`_)
+- Rendered documentation will not be uploaded on cron builds. (`#98`_)
+- Docs script will now clean up the built doc directory before execution, if it exists
+  (e.g., because the docs job is being rerun). (`#96`_)
+
+.. _#96: https://github.com/nengo/nengo-bones/pull/96
+.. _#98: https://github.com/nengo/nengo-bones/pull/98
+
+0.11.0 (April 13, 2020)
+=======================
 
 **Added**
 
@@ -34,15 +48,8 @@ Release History
 - Will now use ``nengo-bones`` and ``nengo-sphinx-theme`` master builds (instead of the
   latest release), to streamline the process of distributing changes to those core
   repos. (`#97`_)
-- Rendered documentation will not be uploaded if the html build fails (it will still
-  be uploaded if the linkchecker/doctest builds fail). (`#98`_)
-- Rendered documentation will not be uploaded on cron builds. (`#98`_)
-- Docs script will now clean up the built doc directory before execution, if it exists
-  (e.g., because the docs job is being rerun). (`#96`_)
 
 .. _#97: https://github.com/nengo/nengo-bones/pull/97
-.. _#98: https://github.com/nengo/nengo-bones/pull/98
-.. _#96: https://github.com/nengo/nengo-bones/pull/96
 
 0.10.0 (March 19, 2020)
 =======================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ Release History
    - Removed
    - Fixed
 
+20.5 (unreleased)
+=================
+
+
 0.11.1 (April 13, 2020)
 =======================
 

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -1,21 +1,17 @@
 """nengo-bones version information.
 
-We use semantic versioning (see http://semver.org/).
+We use calendar versioning (see https://calver.org/)
 and conform to PEP440 (see https://www.python.org/dev/peps/pep-0440/).
 '.devN' will be added to the version unless the code base represents
 a release version. Release versions are git tagged with the version.
-
-The API of nengo-bones is different from other libraries, so we increment
-version numbers as follows:
-
-1. Major version when command line scripts change significantly.
-2. Minor version when changes require patches to downstream projects.
-3. Patch version when changes do not require downstream patches.
 """
 
+from datetime import date
+
 name = "nengo-bones"
-version_info = (0, 11, 1)  # (major, minor, patch)
-dev = None
+today = date.today()
+version_info = (today.year - 2000, today.month)
+dev = 0
 
 version = "{v}{dev}".format(
     v=".".join(str(v) for v in version_info),

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -14,8 +14,8 @@ version numbers as follows:
 """
 
 name = "nengo-bones"
-version_info = (0, 11, 0)  # (major, minor, patch)
-dev = 0
+version_info = (0, 11, 1)  # (major, minor, patch)
+dev = None
 
 version = "{v}{dev}".format(
     v=".".join(str(v) for v in version_info),


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Our new update scheme for Nengo Bones is that updates are pushed to downstream repos immediately (as they depend on `master`), and we'll just do periodic releases, mainly for record keeping purposes. With that in mind it makes sense to switch to a calendar versioning scheme. So this is our last semver release, and then switches the versioning to calver.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Verified that `nengo_bones.__version__` looks correct for dev (`20.4.dev0`) and non-dev (`20.4`) versions.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.