### PR TITLE
Add support for one_page sphinx theme option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 20.5 (unreleased)
 =================
 
+**Added**
+
+- Added support for new ``one_page`` option in ``nengo-sphinx-theme``. (`#101`_)
+
+.. _#101: https://github.com/nengo/nengo-bones/pull/101
 
 0.11.1 (April 13, 2020)
 =======================

--- a/docs/examples/configuration.ipynb
+++ b/docs/examples/configuration.ipynb
@@ -1761,6 +1761,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `one_page` config option can be used for projects that include all of their documentation on a single index page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nengobones_yml = \"\"\"\n",
+    "docs_conf_py:\n",
+    "    one_page: True\n",
+    "\"\"\"\n",
+    "write_yml(nengobones_yml)\n",
+    "\n",
+    "!bones-generate docs-conf-py\n",
+    "display_contents(\"docs/conf.py\", sections=[\"html_theme_options\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Finally, the `sphinx_options` config option can be used to set\n",
     "arbitrary options of the form `var = val` in the conf.py file."
    ]

--- a/nengo_bones/templates/docs/conf.py.template
+++ b/nengo_bones/templates/docs/conf.py.template
@@ -115,6 +115,9 @@ html_theme_options = {
     {% if analytics_id %}
     "analytics_id": "{{ analytics_id }}",
     {% endif %}
+    {% if one_page %}
+    "one_page": True
+    {% endif %}
 }
 {% if html_redirects %}
 html_redirects = [


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Adds support for the new configuration option added in https://github.com/nengo/nengo-sphinx-theme/pull/59

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Depends on https://github.com/nengo/nengo-sphinx-theme/pull/59, and downstream repos will be added in the projects that use the one_page option.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added to config notebook, and functionality will be tested in the downstream repos.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.