### PR TITLE
Fix style warning in static.sh

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -143,7 +143,7 @@ setup_py:
   # note: docs/tests_req are intentionally empty to test that the correct
   # requirements are built into the ci scripts
   install_req:
-    - black>=19.3b0; python_version>='3.6'
+    - black>=20.8b0; python_version>='3.6'
     - click>=7.0
     - jinja2>=2.11
     - pyyaml>=5.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b0
     hooks:
     - id: black
       exclude: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,9 +33,11 @@ Release History
 - Enable the new `pip dependency resolver
   <https://pip.pypa.io/en/stable/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020>`_
   during CI. (`#110`_)
+- Increased minimum ``black`` version to 20.8b0. (`#104`_)
 
 .. _#101: https://github.com/nengo/nengo-bones/pull/101
 .. _#103: https://github.com/nengo/nengo-bones/pull/103
+.. _#104: https://github.com/nengo/nengo-bones/pull/104
 .. _#110: https://github.com/nengo/nengo-bones/pull/110
 
 0.11.1 (April 13, 2020)

--- a/nengo_bones/templates/.pre-commit-config.yaml.template
+++ b/nengo_bones/templates/.pre-commit-config.yaml.template
@@ -2,7 +2,7 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b0
     hooks:
     - id: black
       {% if exclude %}

--- a/nengo_bones/templates/static.sh.template
+++ b/nengo_bones/templates/static.sh.template
@@ -54,7 +54,7 @@ shopt -s globstar
     N_COMMITS=$(git rev-list --count HEAD ^origin/master)
     for ((i=0; i<N_COMMITS; i++)) do
         {# TODO: way to get this working properly with exe? #}
-        git log -n 1 --skip $i --pretty=%B \
+        git log -n 1 --skip "$i" --pretty=%B \
             | grep -v '^Co-authored-by:' \
             | gitlint -vvv || STATUS=1
     done

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -518,10 +518,18 @@ def test_setup_py(tmpdir):
     assert has_line('    "pkg1>=3"')
     assert has_line("setup(")
     assert has_line("    package_data={")
-    assert has_line('        "dummy": ["dummy-data/file1",]')
-    assert has_line('        "other": ["other-data/file2", "other-data/file3",]')
-    assert has_line('    entry_points={"point.a": ["a = b", "c = d",],}')
-    assert has_line('    classifiers=["Classifier :: 1", "ClassifierTwo :: B",]')
+    assert has_line('        "dummy": [')
+    assert has_line('            "dummy-data/file1",')
+    assert has_line('        "other": [')
+    assert has_line('            "other-data/file2",')
+    assert has_line('            "other-data/file3",')
+    assert has_line("    entry_points={")
+    assert has_line('        "point.a": [')
+    assert has_line('            "a = b",')
+    assert has_line('            "c = d",')
+    assert has_line("    classifiers=[")
+    assert has_line('        "Classifier :: 1",')
+    assert has_line('        "ClassifierTwo :: B",')
 
 
 def test_setup_cfg(tmpdir):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ root = os.path.dirname(os.path.realpath(__file__))
 version = runpy.run_path(os.path.join(root, "nengo_bones", "version.py"))["version"]
 
 install_req = [
-    "black>=19.3b0; python_version>='3.6'",
+    "black>=20.8b0; python_version>='3.6'",
     "click>=7.0",
     "jinja2>=2.11",
     "pyyaml>=5.1",


### PR DESCRIPTION
**Motivation and context:**
I get this shellcheck failure in Nengo core:

```
$ shellcheck -e SC2087 .ci/deploy.sh .ci/docs.sh .ci/static.sh .ci/test-coverage-scipy.sh .ci/test-coverage.sh .ci/test.sh

In .ci/static.sh line 73:
        git log -n 1 --skip $i --pretty=%B \
                            ^-- SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
        git log -n 1 --skip "$i" --pretty=%B \
```

Not sure why TravisCI isn't reporting the same, but presumably it should / will eventually report it?

**How has this been tested?**
After this change, I no longer get the above error in Nengo core.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
