### PR TITLE
Avoid Sphinx 3.1.0 version

### DIFF
--- a/nengo_bones/templates/docs.sh.template
+++ b/nengo_bones/templates/docs.sh.template
@@ -5,7 +5,7 @@
 {% block install %}
 {{ super() }}
     exe pip install \
-        "sphinx>=1.8.0" \
+        "sphinx>=1.8.0,<3.1.0" \
         "jupyter>=1.0.0" \
         "nbsphinx>=0.2.13" \
         "numpydoc>=0.6.0" \


### PR DESCRIPTION
**Motivation and context:**
Our doc builds are failing for the same reason reported in https://github.com/sphinx-doc/sphinx/issues/7806. Hopefully Sphinx fixes it soon; until then, easiest fix is to avoid that version until we know it's fixed.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
