### PR TITLE
Properly escape directory in autoupdate script

### DIFF
--- a/.templates/auto-update.sh.template
+++ b/.templates/auto-update.sh.template
@@ -19,7 +19,7 @@
         exe git push -fq "https://$GH_TOKEN@github.com/{{ repo }}" master:bones-autoupdate
         echo "Updated {{ repo }}:bones-autoupdate"
     fi
-    cd .. || exit
+    cd ../.. || exit
 
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

In the autoupdate script we clone everything into a nested directory (e.g. `nengo/nengo-dl`), but were only escaping up one directory, so we'd end up with `nengo/nengo/nengo/nengo/...` as we iterate through the list. It technically worked, but was weird.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Hasn't been tested, because this script doesn't run except in master. We could technically set up a whole dummy branch to run this, and push to dummy branches in the downstream repos, but that seems like more work than is warranted by this simple change.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [ ] I have run the test suite locally and all tests passed.