### PR TITLE
Remove "scrolled" metadata from notebooks

### DIFF
--- a/nengo_bones/scripts/format_notebook.py
+++ b/nengo_bones/scripts/format_notebook.py
@@ -115,6 +115,7 @@ def format_code(cell):
 
     # clear useless metadata
     clear_cell_metadata_entry(cell, "collapsed")
+    clear_cell_metadata_entry(cell, "scrolled")
     clear_cell_metadata_entry(cell, "deletable", value=True)
     clear_cell_metadata_entry(cell, "editable", value=True)
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Just ran into this additional metadata that wasn't being cleared from notebooks (this appears if you run a notebook and then select the "Toggle Scrolling" option).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Tested that it worked in the notebook where this appeared for me, but we're already testing the `clear_cell_metadata_entry` so I didn't add a new test for this particular attribute.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.