### PR TITLE
Add remote-script template

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -20,6 +20,7 @@ travis_yml:
         TEST_LOCAL_VAR: test local var val
       test_args: --test-arg --test-arg
     - script: remote
+    - script: remote-test
     - script: test-coverage
       env:
         TEST_LOCAL_VAR: test local var val
@@ -96,6 +97,20 @@ ci_scripts:
     post_commands:
       - export TEST_POST_COMMANDS=True
   - template: remote
+    pre_commands:
+      - cat .ci/remote.sh
+    travis_var_key: 5820152da3b2
+    host: gl
+  - template: test
+    pre_commands:
+      - cat .ci/test-for-remote.sh
+    output_name: test-for-remote
+    coverage: true
+  - template: remote-script
+    pre_commands:
+      - cat .ci/remote-test.sh
+    remote_script: test-for-remote
+    output_name: remote-test
     travis_var_key: 5820152da3b2
     host: gl
     coverage: true

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -117,6 +117,7 @@ ci_scripts:
       - cat .ci/auto-update.sh
     repos:
       - nengo/keras-spiking
+      - nengo/lmu
       - nengo/nengo
       - nengo/nengo-control
       - nengo/nengo-de1

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ jobs:
       SCRIPT="remote"
   -
     env:
+      SCRIPT="remote-test"
+  -
+    env:
       TEST_LOCAL_VAR="test local var val"
       SCRIPT="test-coverage"
       TEST_ARGS="--test-arg"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Release History
   and static checking to Jupyter notebooks. (`#32`_)
 - Static script will now check that ``bones-format-notebook`` has been applied to all
   notebooks in the ``docs`` directory. (`#32`_)
+- Added ``remote-script.sh`` CI script for running other CI scripts on a remote device.
+  (`#124`_)
 
 **Changed**
 
@@ -51,6 +53,7 @@ Release History
 .. _#110: https://github.com/nengo/nengo-bones/pull/110
 .. _#114: https://github.com/nengo/nengo-bones/pull/114
 .. _#117: https://github.com/nengo/nengo-bones/pull/117
+.. _#124: https://github.com/nengo/nengo-bones/pull/124
 
 0.11.1 (April 13, 2020)
 =======================

--- a/README.rst
+++ b/README.rst
@@ -38,13 +38,8 @@ templating system, so if you would like an example of how to use it, check out
 Installation
 ============
 
-We recommend installing ``nengo-bones`` using ``pip``:
-
-.. code-block:: bash
-
-    pip install nengo-bones
-
-Or for the latest updates you can perform a developer installation:
+NengoBones is designed to be used based on the ``master`` branch (although we
+release occasional stable checkpoints to PyPI). This can be installed via
 
 .. code-block:: bash
 

--- a/nengo_bones/templates/remote-script.sh.template
+++ b/nengo_bones/templates/remote-script.sh.template
@@ -1,0 +1,58 @@
+{% extends "templates/remote.sh.template" %}
+
+{% block remote_install %}
+{{ super() }}
+        # copy environment variables into remote environment
+        export TRAVIS_JOB_NUMBER="$TRAVIS_JOB_NUMBER"
+        export TRAVIS_BRANCH="$TRAVIS_BRANCH"
+        export TRAVIS_TAG="$TRAVIS_TAG"
+        export TEST_ARGS="$TEST_ARGS"
+        export PIP_USE_FEATURE="$PIP_USE_FEATURE"
+        {% if remote_vars %}
+        {% for var, val in remote_vars.items() %}
+        export {{ var }}="{{ val }}"
+        {% endfor %}
+        {% endif %}
+
+        # generate CI scripts on remote device
+        # ensure nengo-bones version is the same as the one installed on host
+        pip install $(pip freeze | grep nengo-bones | awk '{print $(NF)}')
+        bones-generate --output-dir .ci ci-scripts || REMOTE_STATUS=1
+
+        {% for line in remote_setup %}
+        {{ line }}
+        {% endfor %}
+
+        bash .ci/{{ remote_script }}.sh install || REMOTE_STATUS=1
+{% endblock %}
+
+{% block remote_script %}
+{{ super() }}
+        export TRAVIS_JOB_NUMBER="$TRAVIS_JOB_NUMBER"
+        export TRAVIS_BRANCH="$TRAVIS_BRANCH"
+        export TRAVIS_TAG="$TRAVIS_TAG"
+        export TEST_ARGS="$TEST_ARGS{% if coverage %} --cov-report=xml{% endif %}"
+        export PIP_USE_FEATURE="$PIP_USE_FEATURE"
+        {% for var in remote_vars %}
+        export {{ var }}="${{ var }}"
+        {% endfor %}
+
+        echo "Waiting for lock on device $DEVICE_ID"
+        (
+            flock -x -w 540 200 || exit 1
+            bash .ci/{{ remote_script }}.sh script || exit 1
+        ) 200>/var/lock/.travis-ci.exclusivelock."$DEVICE_ID" || REMOTE_STATUS=1
+{% endblock %}
+
+{% block after_script %}
+    {% if remote_script == "docs" %}
+    REMOTE_FAILED_FILE="tmp/{{ pkg }}-$TRAVIS_JOB_NUMBER/{{ pkg }}/$TRAVIS_JOB_NUMBER.failed"
+    ssh -q {{ host }} [[ -e "$REMOTE_FAILED_FILE" ]] && exe scp {{ host }}:"$REMOTE_FAILED_FILE" .
+    exe rsync -azh "{{ host }}:./tmp/{{ pkg }}-$TRAVIS_JOB_NUMBER/{{ pkg }}-docs" ..
+    {% elif coverage %}
+    COVERAGE_FILE="tmp/{{ pkg }}-$TRAVIS_JOB_NUMBER/{{ pkg }}/coverage.xml"
+    exe scp {{ host }}:"$COVERAGE_FILE" .
+    {% endif %}
+    exe bash .ci/{{ remote_script }}.sh after_script
+{{ super() }}
+{% endblock %}

--- a/nengo_bones/templates/remote.sh.template
+++ b/nengo_bones/templates/remote.sh.template
@@ -68,6 +68,19 @@ See https://docs.travis-ci.com/user/encrypting-files/ for more details.
     exe mkdir -p ~/.ssh
     exe tar xvf .ci/secret.tar -C ~/.ssh --overwrite
     exe chmod 600 ~/.ssh/id_rsa
+
+    {% if azure_name %}
+    if ssh {{ host }} -q exit; then
+        echo "VM already running"
+    else
+        echo "Starting VM"
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        exe chmod 400 ~/.ssh/azure.pem
+        exe az login --service-principal -u http://travis-ci -p ~/.ssh/azure.pem --tenant appliedbrainresearch.com
+        exe az vm start --resource-group {{ azure_group }} --name {{ azure_name }}
+    fi
+    {% endif %}
+
     ssh {{ host }} -q "echo 'Connected to {{ host }}'"
 {% endblock %}
 
@@ -99,10 +112,6 @@ EOF
 {% endblock %}
 
 {% block after_script %}
-    {% if coverage %}
-    exe scp "{{ host }}:./tmp/{{ pkg }}-$TRAVIS_JOB_NUMBER/{{ pkg }}/coverage.xml" coverage.xml
-    eval "bash <(curl -s https://codecov.io/bash)"
-    {% endif %}
     exe ssh {{ host }} -q << EOF
         echo "$ ({{ host }}) Cleaning up {{ pkg }}"
         cd ~/tmp

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -49,6 +49,17 @@ def test_ci_scripts(tmpdir):
               - post command 1
           - template: docs
           - template: deploy
+          - template: remote-script
+            remote_script: test
+            output_name: remote-test
+            azure_name: azure-name
+            azure_group: azure-group
+            coverage: true
+          - template: remote-script
+            remote_script: docs
+            output_name: remote-docs
+            remote_vars:
+              remote_var: remote_val
     """,
     )
 
@@ -105,6 +116,17 @@ def test_ci_scripts(tmpdir):
     )
 
     assert has_line(".ci/deploy.sh", 'exe python -c "from dummy import version')
+
+    assert has_line(
+        ".ci/remote-test.sh",
+        "exe az vm start --resource-group azure-group --name azure-name",
+    )
+    assert has_line(".ci/remote-test.sh", "bash .ci/test.sh install")
+    assert has_line(".ci/remote-test.sh", 'COVERAGE_FILE="tmp/dummy')
+
+    assert has_line(".ci/remote-docs.sh", 'export remote_var="remote_val"')
+    assert has_line(".ci/remote-docs.sh", "bash .ci/docs.sh install")
+    assert has_line(".ci/remote-docs.sh", 'REMOTE_FAILED_FILE="tmp/dummy')
 
 
 def test_travis_yml(tmpdir):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Something that has come up a lot is that we want to run one of the CI scripts on some remote machine. This script builds on top of the more general `remote.sh` template to make that specific use case easier.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

NengoDL, KerasSpiking, and NengoFPGA all currently have their own versions of this script; we should switch them over to using this template (and make sure that this script covers all those use cases).

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Added some tests on the content of the rendered script, as well as a new functional job which runs the test script on a remote.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.