### PR TITLE
Simplify remote script environment variables

### DIFF
--- a/nengo_bones/templates/remote-script.sh.template
+++ b/nengo_bones/templates/remote-script.sh.template
@@ -1,18 +1,24 @@
 {% extends "templates/remote.sh.template" %}
 
-{% block remote_install %}
-{{ super() }}
+{% set env_vars %}
+{% block env_vars %}
         # copy environment variables into remote environment
         export TRAVIS_JOB_NUMBER="$TRAVIS_JOB_NUMBER"
         export TRAVIS_BRANCH="$TRAVIS_BRANCH"
         export TRAVIS_TAG="$TRAVIS_TAG"
-        export TEST_ARGS="$TEST_ARGS"
+        export TEST_ARGS="$TEST_ARGS{% if coverage %} --cov-report=xml{% endif %}"
         export PIP_USE_FEATURE="$PIP_USE_FEATURE"
         {% if remote_vars %}
         {% for var, val in remote_vars.items() %}
         export {{ var }}="{{ val }}"
         {% endfor %}
         {% endif %}
+{% endblock %}
+{% endset %}
+
+{% block remote_install %}
+{{ super() }}
+{{ env_vars }}
 
         # generate CI scripts on remote device
         # ensure nengo-bones version is the same as the one installed on host
@@ -28,14 +34,7 @@
 
 {% block remote_script %}
 {{ super() }}
-        export TRAVIS_JOB_NUMBER="$TRAVIS_JOB_NUMBER"
-        export TRAVIS_BRANCH="$TRAVIS_BRANCH"
-        export TRAVIS_TAG="$TRAVIS_TAG"
-        export TEST_ARGS="$TEST_ARGS{% if coverage %} --cov-report=xml{% endif %}"
-        export PIP_USE_FEATURE="$PIP_USE_FEATURE"
-        {% for var in remote_vars %}
-        export {{ var }}="${{ var }}"
-        {% endfor %}
+{{ env_vars }}
 
         echo "Waiting for lock on device $DEVICE_ID"
         (


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

The previous implementation copy-pasted the environment variable logic in two places (and one had an error). This fixes that error, and reduces the duplication.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Discovered because it fixes a bug in https://github.com/nengo/nengo-dl/pull/186.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Used in https://github.com/nengo/nengo-dl/pull/186, and it fixed the bug there.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.