### PR TITLE
Omit formatting generated notebooks directories

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -82,7 +82,7 @@ ci_scripts:
       - npm install -g npm stable
       - npm install -g node --force
       - node --version
-      # install prettier for use in formate_notebook
+      # install prettier for use in bones-format-notebook
       - npm install prettier
     post_commands:
       - export TEST_POST_COMMANDS=True

--- a/nengo_bones/scripts/format_notebook.py
+++ b/nengo_bones/scripts/format_notebook.py
@@ -33,7 +33,7 @@ def format_notebook(nb, fname, verbose=False, prettier=None):
     """Formats an opened Jupyter notebook."""
 
     if verbose:
-        print("Formatting", fname)
+        click.echo("Formatting %r" % fname)
 
     passed = True
 
@@ -256,14 +256,15 @@ def apply_static_checker(command, cells):
     result = run_command(command, all_source)
 
     if result.returncode != 0:
-        print("%s errors detected:" % command.split()[0])
-        print(result.stdout)
+        click.echo("%s errors detected:" % command.split()[0])
+        click.echo(result.stdout)
 
     return result.returncode == 0
 
 
 def clear_cell_metadata_entry(cell, key, value="_ANY_"):
-    """Remove metadata entry from a cell
+    """
+    Remove metadata entry from a cell.
 
     Parameters
     ----------
@@ -283,15 +284,13 @@ def clear_cell_metadata_entry(cell, key, value="_ANY_"):
 def format_file(fname, target_version=4, verbose=False, check=False, prettier=None):
     """Formats a file containing a Jupyter notebook."""
 
-    passed = True
-
     with open(fname, "r", encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
 
     if check:
         current = nbformat.writes(nb).splitlines()
 
-    passed &= format_notebook(nb, fname, verbose=verbose, prettier=prettier)
+    passed = format_notebook(nb, fname, verbose=verbose, prettier=prettier)
 
     if check:
         diff = list(
@@ -366,9 +365,7 @@ def format_paths(fnames, **kwargs):
     help="Enable/disable markdown cell formatting with Prettier.",
 )
 def main(files, **kwargs):
-    """
-    Apply standardized formatting to Jupyter notebooks.
-    """
+    """Apply standardized formatting to Jupyter notebooks."""
 
     if kwargs["prettier"] and not HAS_PRETTIER:
         # user explicitly asked for prettier, but it is not installed, so fail

--- a/nengo_bones/scripts/format_notebook.py
+++ b/nengo_bones/scripts/format_notebook.py
@@ -324,6 +324,10 @@ def format_dir(dname, **kwargs):
     """Format all notebooks in a directory."""
 
     assert os.path.isdir(dname)
+    if dname.endswith(".ipynb_checkpoints") or dname.endswith("_build"):
+        click.echo("Ignoring directory %r" % (dname,))
+        return True
+
     fnames = os.listdir(dname)
     fpaths = [
         os.path.join(dname, fname) for fname in fnames if not fname.startswith(".")

--- a/nengo_bones/tests/test_format_notebook.py
+++ b/nengo_bones/tests/test_format_notebook.py
@@ -188,3 +188,14 @@ def test_format_notebook_static(tmpdir):
     # check that pylint/flake8 errors were detected
     assert "undefined-variable" in result.output  # pylint
     assert "F821" in result.output  # flake8
+
+
+def test_format_dir_ignore(tmpdir):
+    rootdir = tmpdir.mkdir("rootdir")
+    rootdir.mkdir("_build")
+    rootdir.mkdir("my.ipynb_checkpoints")
+    rootdir.mkdir("format_this_dir")
+    result = CliRunner().invoke(format_notebook.main, [str(rootdir)])
+    assert re.search("Ignoring directory '[^']*_build'", result.output)
+    assert re.search(r"Ignoring directory '[^']*my\.ipynb_checkpoints'", result.output)
+    assert not re.search(r"Ignoring directory '[^']*format_this_dir'", result.output)


### PR DESCRIPTION
**Motivation and context:**
When running bones-format-nb locally on the `docs` directory I noticed that we were formatting files in the `_build` folder. This fixes that, as well as omitting the `.ipynb_checkpoints` directory. If a file in one of those directories is specified directly on the command line then it will still be formatted.

Since we have not done a release with the `bones-format-notebook` command, I didn't make a changelog entry for this. Also, this PR will not require a `bones-generate` in our downstream repos, so we can merge this quickly without worry.

**How has this been tested?**
Ran this on my `nengo/docs` directory and it correctly omitted the `_build` directory.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
