### PR TITLE
Remove upper bound on sphinx version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,7 @@ Release History
   for deploying to PyPI and TestPyPI, respectively. (`#127`_)
 - Builds for this repository now run on TravisCI.com instead of TravisCI.org. (`#130`_)
 - Drop support for Python 3.5. (`#123`_)
+- Doc script will now install Sphinx>=3.1.2. (`#137`_)
 
 **Fixed**
 
@@ -74,6 +75,7 @@ Release History
 .. _#130: https://github.com/nengo/nengo-bones/pull/130
 .. _#132: https://github.com/nengo/nengo-bones/pull/132
 .. _#136: https://github.com/nengo/nengo-bones/pull/136
+.. _#137: https://github.com/nengo/nengo-bones/pull/137
 
 0.11.1 (April 13, 2020)
 =======================

--- a/nengo_bones/templates/docs.sh.template
+++ b/nengo_bones/templates/docs.sh.template
@@ -5,7 +5,7 @@
 {% block install %}
 {{ super() }}
     exe pip install \
-        "sphinx>=3.0.0,<3.1.0" \
+        "sphinx>=3.1.2" \
         "jupyter>=1.0.0" \
         "nbsphinx>=0.2.13" \
         "numpydoc>=0.6.0" \


### PR DESCRIPTION


**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

In https://github.com/nengo/nengo-bones/pull/106 we pinned Sphinx to <3.1 to avoid a bug introduced there. This bug has since been fixed (as of 3.1.2), so we can set that as the minimum version and remove the upper bound.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Built the docs for nengo and nengo-dl with the most up to date Sphinx (3.4.0), no problems.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.