### PR TITLE
Fix version string

### DIFF
--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -13,6 +13,6 @@ today = date.today()
 version_info = (today.year - 2000, today.month)
 dev = 0
 
-version = (
-    f'{".".join(str(v) for v in version_info)}{".dev{dev}" if dev is not None else ""}'
+version = ".".join(str(v) for v in version_info) + (
+    f".dev{dev}" if dev is not None else ""
 )


### PR DESCRIPTION
**Motivation and context:**
I did a `pip list` and noticed that the NengoBones version string was wrong. We were outputting versions like

   21.1.dev{dev}

Turns out, we got a bit overzealous with our f-strings and made something pretty inscrutable so we missed an `f` in the nested string.

With this PR the version is now correctly

   21.1.dev0

and does this without nested f-strings, which are hard to read.

**How has this been tested?**
Redid `pip list` and it looks correct now. Also checked by importing and printing `nengo_bones.version.version`.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [na] I have run the test suite locally and all tests passed.
