### PR TITLE
Add support for typed projects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.6.4
     hooks:
-      - id: isort
-        files: \.py$
+    - id: isort
+      files: \.py$

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Release History
 - Added ``skip`` option to codespell config, which can be used to specify files that
   should be ignored. (`#138`_)
 - Added support for projects with type hints through the ``py_typed`` section. (`#140`_)
+- Added ``min_python`` option to the main section. The default ``python_requires``
+  in ``setup.py`` is now based on this, if not overridden. (`#140`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Release History
 - Officially support and test against Python 3.9. (`#136`_)
 - Added ``skip`` option to codespell config, which can be used to specify files that
   should be ignored. (`#138`_)
+- Added support for projects with type hints through the ``py_typed`` section. (`#140`_)
 
 **Changed**
 
@@ -84,6 +85,7 @@ Release History
 .. _#136: https://github.com/nengo/nengo-bones/pull/136
 .. _#137: https://github.com/nengo/nengo-bones/pull/137
 .. _#138: https://github.com/nengo/nengo-bones/pull/138
+.. _#140: https://github.com/nengo/nengo-bones/pull/140
 
 0.11.1 (April 13, 2020)
 =======================

--- a/docs/examples/configuration.ipynb
+++ b/docs/examples/configuration.ipynb
@@ -92,7 +92,8 @@
     "- `copyright_start`: The year the project was first publicly available (defaults to\n",
     "  current year).\n",
     "- `copyright_end`: The last year work was done on the project (defaults to current\n",
-    "  year)."
+    "  year).\n",
+    "- `min_python`: Minimum Python version (defaults to \"3.6\")."
    ]
   },
   {
@@ -1397,7 +1398,8 @@
     "There are a number of options that will be passed to the `setup` function:\n",
     "\n",
     "- `url`: A link to the project's homepage (defaults to nengo.ai/my-package).\n",
-    "- `python_requires`: Python version requirement for this package (defaults to >=3.6).\n",
+    "- `python_requires`: Python version requirement for this package\n",
+    "  (defaults to `'>={{ min_python }}'`).\n",
     "- `include_package_data`: Whether or not to include files listed in `MANIFEST.in` in the\n",
     "  installation (defaults to False).\n",
     "- `package_data`: Mapping of extra data files to include in installation (not specified\n",
@@ -1420,7 +1422,7 @@
     "nengobones_yml = \"\"\"\n",
     "setup_py:\n",
     "    url: https://github.com/org/my-package\n",
-    "    python_requires: \">=3.4\"\n",
+    "    python_requires: \">=3.4,<3.9\"\n",
     "    include_package_data: true\n",
     "    package_data:\n",
     "        pkg:\n",

--- a/docs/examples/configuration.ipynb
+++ b/docs/examples/configuration.ipynb
@@ -1837,6 +1837,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## py.typed config\n",
+    "\n",
+    "The `py.typed` file lets other Python packages know that your package has type hints.\n",
+    "The file has no contents, so there is nothing to configure,\n",
+    "but we use the presence of this config section\n",
+    "to generate the file and modify other templates,\n",
+    "such as adding a `mypy` check in `.ci/static.sh`.\n",
+    "See [PEP-561](https://www.python.org/dev/peps/pep-0561/) for more context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nengobones_yml = \"\"\"\n",
+    "py_typed: {}\n",
+    "\"\"\"\n",
+    "write_yml(nengobones_yml)\n",
+    "\n",
+    "!bones-generate py-typed\n",
+    "list(pathlib.Path(\"eg_package\").iterdir())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/nengo_bones/__init__.py
+++ b/nengo_bones/__init__.py
@@ -18,6 +18,7 @@ all_sections = [
     "manifest_in",
     "pre_commit_config_yaml",
     "pyproject_toml",
+    "py_typed",
 ]
 
 all_files = [
@@ -32,4 +33,5 @@ all_files = [
     "MANIFEST.in",
     ".pre-commit-config.yaml",
     "pyproject.toml",
+    "pkg/py.typed",
 ]

--- a/nengo_bones/config.py
+++ b/nengo_bones/config.py
@@ -72,6 +72,7 @@ def fill_defaults(config):  # noqa: C901
     config.setdefault("author_email", "info@appliedbrainresearch.com")
     config.setdefault("copyright_start", datetime.datetime.now().year)
     config.setdefault("copyright_end", datetime.datetime.now().year)
+    config.setdefault("min_python", "3.6")
 
     if "travis_yml" in config:
         cfg = config["travis_yml"]
@@ -102,7 +103,7 @@ def fill_defaults(config):  # noqa: C901
     if "setup_py" in config:
         cfg = config["setup_py"]
         cfg.setdefault("license", "Free for non-commercial use")
-        cfg.setdefault("python_requires", ">=3.6")
+        cfg.setdefault("python_requires", f">={config['min_python']}")
         cfg.setdefault("include_package_data", False)
         org_name, repo_name = config["repo_name"].split("/")
         domain = {

--- a/nengo_bones/scripts/format_notebook.py
+++ b/nengo_bones/scripts/format_notebook.py
@@ -23,7 +23,7 @@ HAS_PRETTIER = (
 )
 
 
-def format_notebook(nb, fname, verbose=False, prettier=None):
+def format_notebook(nb, fname, verbose=False, prettier=None):  # noqa: C901
     """Formats an opened Jupyter notebook."""
 
     if verbose:
@@ -35,6 +35,9 @@ def format_notebook(nb, fname, verbose=False, prettier=None):
     # Should pass `nengo/tests/test_examples.py:test_minimal_metadata`
     if "kernelspec" in nb.metadata:
         del nb.metadata["kernelspec"]
+
+    if "widgets" in nb.metadata:
+        del nb.metadata["widgets"]
 
     language_info = getattr(nb.metadata, "language_info", {})
     badinfo = (

--- a/nengo_bones/scripts/generate_bones.py
+++ b/nengo_bones/scripts/generate_bones.py
@@ -192,5 +192,13 @@ def pyproject_toml(ctx):
     render_template(ctx, "pyproject.toml")
 
 
+@main.command()
+@click.pass_context
+def py_typed(ctx):
+    """Generate {{ pkg_name }}/py.typed file."""
+
+    render_template(ctx, "pkg/py.typed")
+
+
 if __name__ == "__main__":
     main(obj={})  # pragma: no cover pylint: disable=no-value-for-parameter

--- a/nengo_bones/templates.py
+++ b/nengo_bones/templates.py
@@ -47,6 +47,7 @@ class BonesTemplate:
         self.env = env
 
         section = output_file.lstrip(".")
+        section = section.replace("pkg/", "")  # Don't require `pkg_` prefix
         section = section.replace(".", "_")
         section = section.replace("/", "_")
         section = section.replace("-", "_")
@@ -150,6 +151,11 @@ class BonesTemplate:
         if output_name is None:
             output_name = self.output_file
 
+        # Special case: templates in `templates/pkg` directory have `pkg` replaced
+        # with the actual name of the package
+        if output_name.startswith("pkg/"):
+            assert "pkg_name" in data
+            output_name = output_name.replace("pkg/", f"{data['pkg_name']}/")
         output_path = pathlib.Path(output_dir, output_name)
         output_path.parent.mkdir(exist_ok=True)
         output_path.write_text(self.render(**data))

--- a/nengo_bones/templates/.pre-commit-config.yaml.template
+++ b/nengo_bones/templates/.pre-commit-config.yaml.template
@@ -17,5 +17,12 @@ repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.6.4
     hooks:
-      - id: isort
-        files: \.py$
+    - id: isort
+      files: \.py$
+{% if py_typed is defined %}
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.800
+    hooks:
+    - id: mypy
+      files: \.py$
+{% endif %}

--- a/nengo_bones/templates/MANIFEST.in.template
+++ b/nengo_bones/templates/MANIFEST.in.template
@@ -12,6 +12,9 @@ include *.toml
 include MANIFEST.in
 include .gitlint
 include .pylintrc
+{% if py_typed is defined %}
+include {{ pkg_name}}/py.typed
+{% endif %}
 
 # Directories to include
 graft docs

--- a/nengo_bones/templates/pyproject.toml.template
+++ b/nengo_bones/templates/pyproject.toml.template
@@ -4,7 +4,7 @@
 requires = ["setuptools", "wheel"]
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py{{ min_python | replace(".", "") }}']
 {% if exclude %}
 exclude = '''
 (

--- a/nengo_bones/templates/setup.cfg.template
+++ b/nengo_bones/templates/setup.cfg.template
@@ -181,3 +181,10 @@ skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./.git,*/_vendor,{{ codespell
 ignore-words-list = {{ codespell.ignore_words | join(",") }}
 {% endif %}
 {% endblock %}
+{%- if py_typed is defined %}
+
+{% block mypy %}
+[mypy]
+python_version = 3.6
+{% endblock %}
+{% endif %}

--- a/nengo_bones/templates/setup.cfg.template
+++ b/nengo_bones/templates/setup.cfg.template
@@ -185,6 +185,6 @@ ignore-words-list = {{ codespell.ignore_words | join(",") }}
 
 {% block mypy %}
 [mypy]
-python_version = 3.6
+python_version = {{ min_python }}
 {% endblock %}
 {% endif %}

--- a/nengo_bones/templates/static.sh.template
+++ b/nengo_bones/templates/static.sh.template
@@ -8,10 +8,23 @@ shopt -s globstar
 
 {% block install %}
 {{ super() }}
-    exe pip install "jupyter>=1.0.0" "pylint>=2.5.1" "codespell>=2.0.0" "gitlint>=0.1.2" "collective.checkdocs>=0.2" "flake8>=3.7.7" "isort>=5.6.4"
+    exe pip install \
+        "jupyter>=1.0.0" \
+        "pylint>=2.5.1" \
+        "codespell>=2.0.0" \
+        "gitlint>=0.1.2" \
+        "collective.checkdocs>=0.2" \
+        "flake8>=3.7.7" \
+        {% if py_typed is defined %}
+        "mypy>=0.800" \
+        {% endif %}
+        "isort>=5.6.4"
 {% endblock %}
 
 {% block script %}
+    {% if py_typed is defined %}
+    exe mypy {{ pkg_name }}
+    {% endif %}
     exe pylint {{ pkg_name }} --jobs=0
     exe flake8 {{ pkg_name }}
     exe isort {{ pkg_name }} --check

--- a/nengo_bones/tests/test_config.py
+++ b/nengo_bones/tests/test_config.py
@@ -95,6 +95,7 @@ def test_load_config(tmp_path):
         "project_name": "Dummy",
         "pkg_name": "dummy",
         "repo_name": "abr/dummy",
+        "min_python": "3.6",
         "author": "A Dummy",
         "author_email": "dummy@dummy.com",
         "copyright_start": 0,

--- a/nengo_bones/tests/test_format_notebook.py
+++ b/nengo_bones/tests/test_format_notebook.py
@@ -28,6 +28,7 @@ def check_notebook(nb_path, correct):
     no_metadata = True
     no_metadata &= "kernelspec" not in nb.metadata
     no_metadata &= "signature" not in nb.metadata
+    no_metadata &= "widgets" not in nb.metadata
 
     badinfo = (
         "codemirror_mode",
@@ -75,6 +76,7 @@ def test_format_notebook(tmp_path):
         "language": "python",
         "name": "python3",
     }
+    nb["metadata"]["widgets"] = {"widget1": "widval"}
     nb["cells"][1]["execution_count"] = 3
     nb["cells"][1]["metadata"]["collapsed"] = True
 

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -784,7 +784,7 @@ def test_generate_all(tmp_path):
     assert_exit(result, 0)
 
     for file_path in all_files:
-        assert (tmp_path / file_path).exists()
+        assert (tmp_path / file_path.replace("pkg/", "dummy/")).exists()
 
 
 def test_generate_none(tmp_path):

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -487,9 +487,9 @@ def test_setup_py(tmp_path):
         project_name: Dummy
         pkg_name: dummy
         repo_name: dummy_org/dummy
+        min_python: 3.8
         setup_py:
           description: My project description
-          python_require: ">=3.6"
           install_req:
             - numpy>=1.11
             - pkg2<8
@@ -533,6 +533,7 @@ def test_setup_py(tmp_path):
     assert has_line("docs_req = [")
     assert has_line('    "pkg1>=3"')
     assert has_line("setup(")
+    assert has_line('    python_requires=">=3.8",')
     assert has_line("    package_data={")
     assert has_line('        "dummy": [')
     assert has_line('            "dummy-data/file1",')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = ["setuptools", "wheel"]
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36']
 exclude = '''
 (
     tests/ignoreme/ignoreme.py


### PR DESCRIPTION
**Motivation and context:**

A few internal projects are now using types. I've been using this branch for those projects, but other people are going to have to be running `mypy` checks soon too, so I fixed up this branch so that the type support is optional. You can opt-in to support by enabling the `py_typed` section, which does two things:

- Adds a {{ pkg_name }}/py.typed file, which lets other packages know that the project is typed.
- Adds mypy checking to static script and pre-commit hook.

The py.typed file is the first templated file we've added that should reside in the package directory. It required a little bit of special case code; specifically, we treat the `templates/pkg` directory as special when generating the section name (we don't include the `pkg_` part) and when saving the file (we replace the `pkg/` part of the path with `{{ pkg_name }}`).

**How has this been tested?**
This is tested in the `test_generate_bones.test_generate_all` test, which required a small fix.

**How long should this take to review?**

- Average (neither quick nor lengthy)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
- [x] Add to config notebook
- [x] Changelog entry
- [x] [Do we need to add `py.typed` to `setup.py` too?](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages)
- [x] Discuss: does this special casing for the package name make sense?