### PR TITLE
Add main_branch option to main section

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -1,6 +1,7 @@
 project_name: NengoBones
 pkg_name: nengo_bones
 repo_name: nengo/nengo-bones
+main_branch: master
 
 description: Tools for managing Nengo projects
 copyright_start: 2018

--- a/.templates/auto-update.sh.template
+++ b/.templates/auto-update.sh.template
@@ -16,7 +16,7 @@
     else
         exe git add --all
         exe git commit -m "Automatic update to NengoBones $COMMIT_HASH" -m "$COMMIT_MSG"
-        exe git push -fq "https://$GH_TOKEN@github.com/{{ repo }}" master:bones-autoupdate
+        exe git push -fq "https://$GH_TOKEN@github.com/{{ repo }}" {{ main_branch }}:bones-autoupdate
         echo "Updated {{ repo }}:bones-autoupdate"
     fi
     cd ../.. || exit

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Release History
 - Added support for projects with type hints through the ``py_typed`` section. (`#140`_)
 - Added ``min_python`` option to the main section. The default ``python_requires``
   in ``setup.py`` is now based on this, if not overridden. (`#140`_)
+- Added support for changing the main branch name with the ``main_branch``
+  config option. (`#145`_)
 
 **Changed**
 
@@ -91,6 +93,7 @@ Release History
 .. _#138: https://github.com/nengo/nengo-bones/pull/138
 .. _#140: https://github.com/nengo/nengo-bones/pull/140
 .. _#144: https://github.com/nengo/nengo-bones/pull/144
+.. _#145: https://github.com/nengo/nengo-bones/pull/145
 
 0.11.1 (April 13, 2020)
 =======================

--- a/docs/examples/configuration.ipynb
+++ b/docs/examples/configuration.ipynb
@@ -93,7 +93,8 @@
     "  current year).\n",
     "- `copyright_end`: The last year work was done on the project (defaults to current\n",
     "  year).\n",
-    "- `min_python`: Minimum Python version (defaults to \"3.6\")."
+    "- `min_python`: Minimum Python version (defaults to \"3.6\").\n",
+    "- `main_branch`: Main `git` branch (defaults to `\"master\"`)."
    ]
   },
   {

--- a/nengo_bones/config.py
+++ b/nengo_bones/config.py
@@ -73,6 +73,7 @@ def fill_defaults(config):  # noqa: C901
     config.setdefault("copyright_start", datetime.datetime.now().year)
     config.setdefault("copyright_end", datetime.datetime.now().year)
     config.setdefault("min_python", "3.6")
+    config.setdefault("main_branch", "master")
 
     if "travis_yml" in config:
         cfg = config["travis_yml"]

--- a/nengo_bones/templates/.travis.yml.template
+++ b/nengo_bones/templates/.travis.yml.template
@@ -8,7 +8,7 @@ notifications:
     on_failure: change
   {% if slack_notifications %}
   slack:
-    if: branch = master
+    if: branch = {{ main_branch }}
     on_pull_requests: false
     on_success: change
     on_failure: always

--- a/nengo_bones/templates/docs.sh.template
+++ b/nengo_bones/templates/docs.sh.template
@@ -56,7 +56,7 @@
     if [[ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
         exe git commit -m "Documentation for release $TRAVIS_TAG"
         exe git push -q "https://$GH_TOKEN@github.com/{{ repo_name }}.git" gh-pages-release
-    elif [[ "$BRANCH_NAME" == "master" ]]; then
+    elif [[ "$BRANCH_NAME" == "{{ main_branch }}" ]]; then
         exe git commit -m "Last update at $(date '+%Y-%m-%d %T')"
         exe git push -fq "https://$GH_TOKEN@github.com/{{ repo_name }}.git" gh-pages-release:gh-pages
     elif [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then

--- a/nengo_bones/templates/static.sh.template
+++ b/nengo_bones/templates/static.sh.template
@@ -35,8 +35,8 @@ shopt -s globstar
     exe shellcheck -e SC2087 .ci/*.sh
     # undo single-branch cloning
     git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-    git fetch origin master
-    N_COMMITS=$(git rev-list --count HEAD ^origin/master)
+    git fetch origin {{ main_branch }}
+    N_COMMITS=$(git rev-list --count HEAD ^origin/{{ main_branch }})
     for ((i=0; i<N_COMMITS; i++)) do
         {# TODO: way to get this working properly with exe? #}
         git log -n 1 --skip "$i" --pretty=%B \

--- a/nengo_bones/tests/test_config.py
+++ b/nengo_bones/tests/test_config.py
@@ -96,6 +96,7 @@ def test_load_config(tmp_path):
         "pkg_name": "dummy",
         "repo_name": "abr/dummy",
         "min_python": "3.6",
+        "main_branch": "master",
         "author": "A Dummy",
         "author_email": "dummy@dummy.com",
         "copyright_start": 0,


### PR DESCRIPTION
**Motivation and context:**

This option allows repos to use `main` (or anything else) as their default git branch name, instead of the now discouraged `master`. We still set the default value to `master` in order to minimize the number of changes needed to downstream repos, but eventually we should switch this to default to `main`.

This is needed for more recent repos created through TravisCI and the `git init` command.

**How has this been tested?**
Modified `test_load_config` to ensure default value is loaded; ensured that no generated files have changed in this repo, but that they are correct in a downstream repo.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
