### PR TITLE
Remove reference to style guide from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,10 +26,6 @@ If you want to fix a bug or add a feature to NengoBones,
 we welcome pull requests.
 Ensure that you fill out all sections of the pull request template,
 deleting the comments as you go.
-We check most aspects of code style automatically.
-Please refer to our
-`code style guide <https://www.nengo.ai/nengo-bones/style.html>`_
-for things that we check manually.
 
 Contributor agreement
 =====================

--- a/nengo_bones/templates/CONTRIBUTING.rst.template
+++ b/nengo_bones/templates/CONTRIBUTING.rst.template
@@ -26,10 +26,6 @@ If you want to fix a bug or add a feature to {{ project_name }},
 we welcome pull requests.
 Ensure that you fill out all sections of the pull request template,
 deleting the comments as you go.
-We check most aspects of code style automatically.
-Please refer to our
-`code style guide <https://www.nengo.ai/nengo-bones/style.html>`_
-for things that we check manually.
 
 Contributor agreement
 =====================


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

We removed the style guide page, so need to remove the link to it from CONTRIBUTING.rst as well. I thought about trying to add something to CONTRIBUTING.rst describing the style checks we do, but couldn't think of a concise way to do that (I don't think we want to try to be describing all the different tools we use in the contributing document, and keeping that up to date). And thinking back I can't think of any external PRs where that really would have been that helpful, so I think just leaving it out (and dealing with style in any external PRs as they come up) works for now.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

N/A

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.