### PR TITLE
Remove leading zeros from calver version string

### DIFF
--- a/nengo_bones/templates/pkg/version.py.template
+++ b/nengo_bones/templates/pkg/version.py.template
@@ -29,11 +29,7 @@ dev = {% if release %}None{% else %}0{% endif %}
 
 # use old string formatting, so that this can still run in Python <= 3.5
 # (since this file is parsed in setup.py, before python_requires is applied)
-{% if type == "semver" %}
 version = ".".join(str(v) for v in version_info)
-{% elif type == "calver" %}
-version = ".".join("%02d" % v for v in version_info)
-{% endif %}
 if dev is not None:
     version += ".dev%d" % dev
 

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -859,4 +859,4 @@ def test_version_py(version_type, release, tmp_path):
     else:
         today = date.today()
         version_info = (today.year - 2000, today.month, today.day)
-        assert version == ".".join(f"{x:02}" for x in version_info)
+        assert version == ".".join(str(x) for x in version_info)

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -20,7 +20,7 @@ dev = 0
 
 # use old string formatting, so that this can still run in Python <= 3.5
 # (since this file is parsed in setup.py, before python_requires is applied)
-version = ".".join("%02d" % v for v in version_info)
+version = ".".join(str(v) for v in version_info)
 if dev is not None:
     version += ".dev%d" % dev
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

We noticed that the leading zeros get removed by pip (see https://www.python.org/dev/peps/pep-0440/#integer-normalization), so removing them from the version string to make things consistent.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.