### PR TITLE
Prune .mypy_cache from manifest

### DIFF
--- a/nengo_bones/templates/MANIFEST.in.template
+++ b/nengo_bones/templates/MANIFEST.in.template
@@ -27,6 +27,9 @@ prune .github
 prune .tox
 prune .eggs
 prune .ci
+{% if py_typed is defined %}
+prune .mypy_cache
+{% endif %}
 
 # Exclude auto-generated files
 recursive-exclude docs *.py


### PR DESCRIPTION
**Motivation and context:**
When running `check-manifest` in a project with types, you get a lot of warnings about `.mypy_cache`.

**How has this been tested?**
Tested in a downstream project, removes those warnings

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
