### PR TITLE
Automatically fill setup.py license fields

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -182,7 +182,6 @@ setup_py:
     - "Development Status :: 4 - Beta"
     - "Framework :: Nengo"
     - "Intended Audience :: Developers"
-    - "License :: Free for non-commercial use"
     - "Operating System :: Microsoft :: Windows"
     - "Operating System :: POSIX :: Linux"
     - "Programming Language :: Python"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,8 @@ Release History
   (`#138`_)
 - Switched to new version of Codecov uploader and added checksum verification. (`#150`_)
 - Increased minimum ``black`` version to 21.12b0. (`#104`_, `#159`_)
+- License fields in ``setup.py`` are now set using ``license_rst.type``. (`#161`_)
+- Trove classifiers in ``setup.py`` are now sorted alphabetically. (`#161`_)
 
 **Fixed**
 
@@ -97,6 +99,7 @@ Release History
 .. _#151: https://github.com/nengo/nengo-bones/pull/151
 .. _#159: https://github.com/nengo/nengo-bones/pull/159
 .. _#160: https://github.com/nengo/nengo-bones/pull/160
+.. _#161: https://github.com/nengo/nengo-bones/pull/161
 
 0.11.1 (April 13, 2020)
 =======================

--- a/nengo_bones/templates/LICENSE.rst.template
+++ b/nengo_bones/templates/LICENSE.rst.template
@@ -53,7 +53,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -63,205 +63,205 @@ limitations under the License.
 
 ::
 
-|                                  Apache License
-|                            Version 2.0, January 2004
-|                         http://www.apache.org/licenses/
-|
-|    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-|
-|    1. Definitions.
-|
-|       "License" shall mean the terms and conditions for use, reproduction,
-|       and distribution as defined by Sections 1 through 9 of this document.
-|
-|       "Licensor" shall mean the copyright owner or entity authorized by
-|       the copyright owner that is granting the License.
-|
-|       "Legal Entity" shall mean the union of the acting entity and all
-|       other entities that control, are controlled by, or are under common
-|       control with that entity. For the purposes of this definition,
-|       "control" means (i) the power, direct or indirect, to cause the
-|       direction or management of such entity, whether by contract or
-|       otherwise, or (ii) ownership of fifty percent (50%) or more of the
-|       outstanding shares, or (iii) beneficial ownership of such entity.
-|
-|       "You" (or "Your") shall mean an individual or Legal Entity
-|       exercising permissions granted by this License.
-|
-|       "Source" form shall mean the preferred form for making modifications,
-|       including but not limited to software source code, documentation
-|       source, and configuration files.
-|
-|       "Object" form shall mean any form resulting from mechanical
-|       transformation or translation of a Source form, including but
-|       not limited to compiled object code, generated documentation,
-|       and conversions to other media types.
-|
-|       "Work" shall mean the work of authorship, whether in Source or
-|       Object form, made available under the License, as indicated by a
-|       copyright notice that is included in or attached to the work
-|       (an example is provided in the Appendix below).
-|
-|       "Derivative Works" shall mean any work, whether in Source or Object
-|       form, that is based on (or derived from) the Work and for which the
-|       editorial revisions, annotations, elaborations, or other modifications
-|       represent, as a whole, an original work of authorship. For the purposes
-|       of this License, Derivative Works shall not include works that remain
-|       separable from, or merely link (or bind by name) to the interfaces of,
-|       the Work and Derivative Works thereof.
-|
-|       "Contribution" shall mean any work of authorship, including
-|       the original version of the Work and any modifications or additions
-|       to that Work or Derivative Works thereof, that is intentionally
-|       submitted to Licensor for inclusion in the Work by the copyright owner
-|       or by an individual or Legal Entity authorized to submit on behalf of
-|       the copyright owner. For the purposes of this definition, "submitted"
-|       means any form of electronic, verbal, or written communication sent
-|       to the Licensor or its representatives, including but not limited to
-|       communication on electronic mailing lists, source code control systems,
-|       and issue tracking systems that are managed by, or on behalf of, the
-|       Licensor for the purpose of discussing and improving the Work, but
-|       excluding communication that is conspicuously marked or otherwise
-|       designated in writing by the copyright owner as "Not a Contribution."
-|
-|       "Contributor" shall mean Licensor and any individual or Legal Entity
-|       on behalf of whom a Contribution has been received by Licensor and
-|       subsequently incorporated within the Work.
-|
-|    2. Grant of Copyright License. Subject to the terms and conditions of
-|       this License, each Contributor hereby grants to You a perpetual,
-|       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-|       copyright license to reproduce, prepare Derivative Works of,
-|       publicly display, publicly perform, sublicense, and distribute the
-|       Work and such Derivative Works in Source or Object form.
-|
-|    3. Grant of Patent License. Subject to the terms and conditions of
-|       this License, each Contributor hereby grants to You a perpetual,
-|       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-|       (except as stated in this section) patent license to make, have made,
-|       use, offer to sell, sell, import, and otherwise transfer the Work,
-|       where such license applies only to those patent claims licensable
-|       by such Contributor that are necessarily infringed by their
-|       Contribution(s) alone or by combination of their Contribution(s)
-|       with the Work to which such Contribution(s) was submitted. If You
-|       institute patent litigation against any entity (including a
-|       cross-claim or counterclaim in a lawsuit) alleging that the Work
-|       or a Contribution incorporated within the Work constitutes direct
-|       or contributory patent infringement, then any patent licenses
-|       granted to You under this License for that Work shall terminate
-|       as of the date such litigation is filed.
-|
-|    4. Redistribution. You may reproduce and distribute copies of the
-|       Work or Derivative Works thereof in any medium, with or without
-|       modifications, and in Source or Object form, provided that You
-|       meet the following conditions:
-|
-|       (a) You must give any other recipients of the Work or
-|           Derivative Works a copy of this License; and
-|
-|       (b) You must cause any modified files to carry prominent notices
-|           stating that You changed the files; and
-|
-|       (c) You must retain, in the Source form of any Derivative Works
-|           that You distribute, all copyright, patent, trademark, and
-|           attribution notices from the Source form of the Work,
-|           excluding those notices that do not pertain to any part of
-|           the Derivative Works; and
-|
-|       (d) If the Work includes a "NOTICE" text file as part of its
-|           distribution, then any Derivative Works that You distribute must
-|           include a readable copy of the attribution notices contained
-|           within such NOTICE file, excluding those notices that do not
-|           pertain to any part of the Derivative Works, in at least one
-|           of the following places: within a NOTICE text file distributed
-|           as part of the Derivative Works; within the Source form or
-|           documentation, if provided along with the Derivative Works; or,
-|           within a display generated by the Derivative Works, if and
-|           wherever such third-party notices normally appear. The contents
-|           of the NOTICE file are for informational purposes only and
-|           do not modify the License. You may add Your own attribution
-|           notices within Derivative Works that You distribute, alongside
-|           or as an addendum to the NOTICE text from the Work, provided
-|           that such additional attribution notices cannot be construed
-|           as modifying the License.
-|
-|       You may add Your own copyright statement to Your modifications and
-|       may provide additional or different license terms and conditions
-|       for use, reproduction, or distribution of Your modifications, or
-|       for any such Derivative Works as a whole, provided Your use,
-|       reproduction, and distribution of the Work otherwise complies with
-|       the conditions stated in this License.
-|
-|    5. Submission of Contributions. Unless You explicitly state otherwise,
-|       any Contribution intentionally submitted for inclusion in the Work
-|       by You to the Licensor shall be under the terms and conditions of
-|       this License, without any additional terms or conditions.
-|       Notwithstanding the above, nothing herein shall supersede or modify
-|       the terms of any separate license agreement you may have executed
-|       with Licensor regarding such Contributions.
-|
-|    6. Trademarks. This License does not grant permission to use the trade
-|       names, trademarks, service marks, or product names of the Licensor,
-|       except as required for reasonable and customary use in describing the
-|       origin of the Work and reproducing the content of the NOTICE file.
-|
-|    7. Disclaimer of Warranty. Unless required by applicable law or
-|       agreed to in writing, Licensor provides the Work (and each
-|       Contributor provides its Contributions) on an "AS IS" BASIS,
-|       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-|       implied, including, without limitation, any warranties or conditions
-|       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-|       PARTICULAR PURPOSE. You are solely responsible for determining the
-|       appropriateness of using or redistributing the Work and assume any
-|       risks associated with Your exercise of permissions under this License.
-|
-|    8. Limitation of Liability. In no event and under no legal theory,
-|       whether in tort (including negligence), contract, or otherwise,
-|       unless required by applicable law (such as deliberate and grossly
-|       negligent acts) or agreed to in writing, shall any Contributor be
-|       liable to You for damages, including any direct, indirect, special,
-|       incidental, or consequential damages of any character arising as a
-|       result of this License or out of the use or inability to use the
-|       Work (including but not limited to damages for loss of goodwill,
-|       work stoppage, computer failure or malfunction, or any and all
-|       other commercial damages or losses), even if such Contributor
-|       has been advised of the possibility of such damages.
-|
-|    9. Accepting Warranty or Additional Liability. While redistributing
-|       the Work or Derivative Works thereof, You may choose to offer,
-|       and charge a fee for, acceptance of support, warranty, indemnity,
-|       or other liability obligations and/or rights consistent with this
-|       License. However, in accepting such obligations, You may act only
-|       on Your own behalf and on Your sole responsibility, not on behalf
-|       of any other Contributor, and only if You agree to indemnify,
-|       defend, and hold each Contributor harmless for any liability
-|       incurred by, or claims asserted against, such Contributor by reason
-|       of your accepting any such warranty or additional liability.
-|
-|    END OF TERMS AND CONDITIONS
-|
-|    APPENDIX: How to apply the Apache License to your work.
-|
-|       To apply the Apache License to your work, attach the following
-|       boilerplate notice, with the fields enclosed by brackets "[]"
-|       replaced with your own identifying information. (Don't include
-|       the brackets!)  The text should be enclosed in the appropriate
-|       comment syntax for the file format. We also recommend that a
-|       file or class name and description of purpose be included on the
-|       same "printed page" as the copyright notice for easier
-|       identification within third-party archives.
-|
-|    Copyright [yyyy] [name of copyright owner]
-|
-|    Licensed under the Apache License, Version 2.0 (the "License");
-|    you may not use this file except in compliance with the License.
-|    You may obtain a copy of the License at
-|
-|        http://www.apache.org/licenses/LICENSE-2.0
-|
-|    Unless required by applicable law or agreed to in writing, software
-|    distributed under the License is distributed on an "AS IS" BASIS,
-|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-|    See the License for the specific language governing permissions and
-|    limitations under the License.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 {% endif %}

--- a/nengo_bones/tests/test_config.py
+++ b/nengo_bones/tests/test_config.py
@@ -51,6 +51,20 @@ def test_validate_config():
 
     init_cfg["ci_scripts"] = {}
 
+    # error when license type is not recognized
+    test_cfg = {"type": "bsd"}
+    init_cfg["license_rst"] = test_cfg
+    with pytest.raises(ValueError, match='must be "nengo", "mit", or "apache"'):
+        config.validate_config(init_cfg)
+    del init_cfg["license_rst"]
+
+    # error when license classifier manually specified
+    test_cfg = {"classifiers": ["License :: Cool license"]}
+    init_cfg["setup_py"] = test_cfg
+    with pytest.raises(ValueError, match="remove manual entry"):
+        config.validate_config(init_cfg)
+    del init_cfg["setup_py"]
+
     # error when template not defined
     test_cfg = {}
     init_cfg["ci_scripts"] = [test_cfg]
@@ -122,6 +136,7 @@ def test_load_config(tmp_path):
             "python_requires": ">=3.6",
             "include_package_data": False,
             "url": "https://www.appliedbrainresearch.com/dummy",
+            "classifiers": ["License :: Free for non-commercial use"],
         },
     }
 

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -377,7 +377,6 @@ def test_license(tmp_path, license_type):
         assert has_line("**MIT License**")
 
     if license_type == "nengo":
-        assert has_line("**ABR License**")
         assert has_line("Dumdum is made available under a proprietary license")
 
     if license_type == "apache":


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

In looking over https://github.com/nengo/nengo-loihi/pull/325, realized there are a few places where the license type changes things in `setup.py`, and it'd be nice to have these done automatically (unless overridden by the user). This should be particularly helpful to those setting up new projects who may forget to fill these fields otherwise. Also, the previous default for the `license` field didn't check the license type in `license_rst`, so would be wrong for Apache or MIT licenses.

Also, fixed `test_license`, which was accidentally left broken by #160.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Tested with https://github.com/nengo/nengo-loihi/pull/325. 

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.