### PR TITLE
Fix setuptools/importlib-metadata version issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,9 @@ before_install:
     _travis_terminate_unix
     _travis_terminate_windows
   # upgrade pip
-  - pip install pip --upgrade
+  - pip install pip setuptools --upgrade
+  # fixes setuptools bug, see https://github.com/pypa/setuptools/issues/3293
+  - pip install "importlib-metadata>=0.21"
   # install/run nengo-bones
   - pip install git+https://github.com/nengo/nengo-bones.git@$BRANCH_NAME
   - bones-generate --output-dir .ci ci-scripts

--- a/nengo_bones/templates/.travis.yml.template
+++ b/nengo_bones/templates/.travis.yml.template
@@ -86,7 +86,9 @@ before_install:
     _travis_terminate_unix
     _travis_terminate_windows
   # upgrade pip
-  - pip install pip --upgrade
+  - pip install pip setuptools --upgrade
+  # fixes setuptools bug, see https://github.com/pypa/setuptools/issues/3293
+  - pip install "importlib-metadata>=0.21"
   # install/run nengo-bones
   - pip install {{ bones_install }}
   - bones-generate --output-dir .ci ci-scripts

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -298,8 +298,8 @@ def test_ci_script_custom_template(tmp_path):
         """,
     )
 
+    saved = os.getcwd()
     try:
-        saved = os.getcwd()
         os.chdir(tmp_path)
         result = CliRunner().invoke(generate_bones.main, ["ci-scripts"])
     finally:


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

More recent `setuptools` versions require more recent `importlib-metadata` versions, which doesn't get installed automatically by `setuptools`. See https://github.com/pypa/setuptools/issues/3293.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

Depends on https://github.com/nengo/nengo-sphinx-theme/pull/73 (not directly for this functionality, just in order to get the doc build passing)

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

Covered by existing tests.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.