### PR TITLE
Fixes for recent pylint changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,7 @@ Release History
   deeper folder shares the same name. (`#132`_)
 - Fixed an issue in which CI scripts did not have access to the same configuration
   options as other templates. (`#144`_)
+- Removed pylint disable for ``bad-continuation`` as it no longer exists. (`#163`_)
 
 .. _#32: https://github.com/nengo/nengo-bones/pull/32
 .. _#101: https://github.com/nengo/nengo-bones/pull/101
@@ -106,6 +107,7 @@ Release History
 .. _#160: https://github.com/nengo/nengo-bones/pull/160
 .. _#161: https://github.com/nengo/nengo-bones/pull/161
 .. _#162: https://github.com/nengo/nengo-bones/pull/162
+.. _#163: https://github.com/nengo/nengo-bones/pull/163
 
 0.11.1 (April 13, 2020)
 =======================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,7 @@ Release History
 - Fixed an issue in which CI scripts did not have access to the same configuration
   options as other templates. (`#144`_)
 - Removed pylint disable for ``bad-continuation`` as it no longer exists. (`#163`_)
+- Removed pylint disable for ``no-self-use`` as it is now optional. (`#163`_)
 
 .. _#32: https://github.com/nengo/nengo-bones/pull/32
 .. _#101: https://github.com/nengo/nengo-bones/pull/101

--- a/nengo_bones/templates/setup.cfg.template
+++ b/nengo_bones/templates/setup.cfg.template
@@ -116,7 +116,6 @@ disable =
     arguments-differ,
     assignment-from-no-return,
     attribute-defined-outside-init,
-    bad-continuation,
     blacklisted-name,
     comparison-with-callable,
     duplicate-code,

--- a/nengo_bones/templates/setup.cfg.template
+++ b/nengo_bones/templates/setup.cfg.template
@@ -129,7 +129,6 @@ disable =
     no-else-return,
     no-member,
     no-name-in-module,
-    no-self-use,
     not-an-iterable,
     not-context-manager,
     protected-access,

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,6 @@ disable =
     no-else-return,
     no-member,
     no-name-in-module,
-    no-self-use,
     not-an-iterable,
     not-context-manager,
     protected-access,

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,6 @@ disable =
     arguments-differ,
     assignment-from-no-return,
     attribute-defined-outside-init,
-    bad-continuation,
     blacklisted-name,
     comparison-with-callable,
     duplicate-code,


### PR DESCRIPTION
Two checks that we were disabling were either removed or made optional in recent Pylint releases. This PR removes them to fix our static checker.

**How has this been tested?**
Used this branch in `nengo-edge-server`, which was previously failing due to these issues. It now passes.

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [na] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
