### PR TITLE
Export vars in remote.sh.template

### DIFF
--- a/nengo_bones/templates/docs.sh.template
+++ b/nengo_bones/templates/docs.sh.template
@@ -16,7 +16,7 @@
 
 {% block script %}
     if [ -d "{{ docs_dir }}" ]; then exe rm -Rf {{ docs_dir }}; fi
-    exe git clone -b gh-pages-release https://github.com/{{ repo_name }}.git {{ docs_dir }}
+    exe git clone -b gh-pages-release "https://$GH_TOKEN@github.com/{{ repo_name }}.git" {{ docs_dir }}
     RELEASES=$(find {{ docs_dir }} -maxdepth 1 -type d -name "v[0-9].*" -printf "%f,")
 
     FAILED_FILE="$JOB_NUMBER.failed"

--- a/nengo_bones/templates/remote.sh.template
+++ b/nengo_bones/templates/remote.sh.template
@@ -102,8 +102,9 @@ See https://docs.travis-ci.com/user/encrypting-files/ for more details.
 
 {% block script %}
 {{ super() }}
-    BUILD_DIR="tmp/{{ pkg }}-$JOB_NUMBER"
+    export BUILD_DIR="tmp/{{ pkg }}-$JOB_NUMBER"
     PYTHON_VERSION="$(python -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')")"
+    export PYTHON_VERSION
 
     exe ssh {{ host }} -q "mkdir -p tmp"
     exe rsync -azh "$(pwd)" "{{ host }}:./$BUILD_DIR/"

--- a/nengo_bones/tests/test_generate_bones.py
+++ b/nengo_bones/tests/test_generate_bones.py
@@ -121,7 +121,7 @@ def test_ci_scripts(tmp_path):
     assert has_line(
         ".ci/docs.sh",
         "exe git clone -b gh-pages-release "
-        "https://github.com/dummy/dummy_repo.git ../dummy_repo-docs",
+        '"https://$GH_TOKEN@github.com/dummy/dummy_repo.git" ../dummy_repo-docs',
     )
 
     assert has_line(".ci/deploy.sh", 'exe python -c "from dummy import version')


### PR DESCRIPTION
This prevents shellcheck warnings in case subclassed templates don't use these variables.