### PR TITLE
Fix remote cleanup block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
   test:
     needs:
       - static
-    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -51,12 +50,14 @@ jobs:
             test_local_var: test local var val
             test_args: --test-arg
             python: "3.6"
+            runs-on: ubuntu-20.04
             coverage-name: test-coverage-3.6
           - script: test-nengo
             test_local_var: test local var val
             test_args: --test-arg
             python: "3.9"
       fail-fast: false
+    runs-on: ${{ matrix.runs-on || 'ubuntu-latest' }}
     env:
       SCRIPT: ${{ matrix.script }}
       TEST_GLOBAL_VAR: test global var val

--- a/nengo_bones/templates/remote.sh.template
+++ b/nengo_bones/templates/remote.sh.template
@@ -108,9 +108,14 @@ EOF
           flock -x -w 540 200 || exit 1
           echo "$ Obtained cleanup lock"
           {% block remote_cleanup %}
-          find . -mtime +1 -type d | grep '{{ pkg }}-' | xargs -I {} rm -r -- {}
+          if [ $(df -B1 -P . | tail -1 | awk '{print $4}') -lt '5368709120' ]; then
+            echo "$ ({{ host }}) < 5G disk space left, clearing ~/tmp"
+            find . -mindepth 1 -maxdepth 1 -mmin +59 -exec rm -r -- {} +
+          else
+            find . -maxdepth 1 -mtime +1 -type d -name '{{ pkg }}-*' -exec rm -r -- {} +
+          fi
           {% endblock %}
-        ) 200>cleanup.lock
+        ) 200>../tmpcleanup.lock
         exit \$?
 EOF
 {% endblock %}


### PR DESCRIPTION
**Motivation and context:**
This block was erroring out previously because find and rm -r traverse files differently, resulting in find trying to look in directories that no longer exist. This new snippet should avoid those issues in several ways, and also be a bit simpler and faster by letting `find` do more of the work.

**How has this been tested?**
Currently testing in https://github.com/nengo/keras-lmu/pull/50

**How long should this take to review?**

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [na] I have included a changelog entry.
- [na] I have added tests to cover my changes.
- [na] I have run the test suite locally and all tests passed.
