### PR TITLE
Avoid docformatter 1.5.1

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -124,7 +124,7 @@ setup_py:
     - black>=21.12b0
     - click>=7.0
     - codespell>=2.0.0
-    - docformatter>=1.5.0
+    - docformatter>=1.5.0,!=1.5.1
     - flake8>=3.7.7
     - jinja2>=2.11
     - jupyter>=1.0.0

--- a/nengo_bones/templates/static.sh.template
+++ b/nengo_bones/templates/static.sh.template
@@ -20,7 +20,7 @@ shopt -s globstar
         "mypy>=0.800" \
         {% endif %}
         "isort>=5.6.4" \
-        "docformatter>=1.5.0"
+        "docformatter>=1.5.0,!=1.5.1"
 {% endblock %}
 
 {% block script %}

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_req = [
     "black>=21.12b0",
     "click>=7.0",
     "codespell>=2.0.0",
-    "docformatter>=1.5.0",
+    "docformatter>=1.5.0,!=1.5.1",
     "flake8>=3.7.7",
     "jinja2>=2.11",
     "jupyter>=1.0.0",


### PR DESCRIPTION
There are some bugs in the new docformatter release, see https://github.com/PyCQA/docformatter/issues/140. I went with just avoiding the problematic version, anticipating that it will be fixed in future releases, but we could also just set an upper bound.