### PR TITLE
Update black version

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -121,7 +121,7 @@ setup_py:
   # note: docs/tests_req are intentionally empty to test that the correct
   # requirements are built into the ci scripts
   install_req:
-    - black>=21.12b0
+    - black>=22.1.0
     - click>=7.0
     - codespell>=2.0.0
     - docformatter>=1.5.0,!=1.5.1

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 NengoBones license
 ******************
 
-Copyright (c) 2018-2022 Applied Brain Research
+Copyright (c) 2018-2023 Applied Brain Research
 
 **ABR License**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ suppress_warnings = ["image.nonlocal_uri"]
 
 project = "NengoBones"
 authors = "Applied Brain Research"
-copyright = "2018-2022 Applied Brain Research"
+copyright = "2018-2023 Applied Brain Research"
 version = ".".join(nengo_bones.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_bones.__version__  # Full version, with tags
 

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -25,4 +25,4 @@ version = ".".join(str(v) for v in version_info)
 if dev is not None:
     version += ".dev%d" % dev
 
-copyright = "Copyright (c) 2018-2022 Applied Brain Research"
+copyright = "Copyright (c) 2018-2023 Applied Brain Research"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ root = pathlib.Path(__file__).parent
 version = runpy.run_path(str(root / "nengo_bones" / "version.py"))["version"]
 
 install_req = [
-    "black>=21.12b0",
+    "black>=22.1.0",
     "click>=7.0",
     "codespell>=2.0.0",
     "docformatter>=1.5.0,!=1.5.1",


### PR DESCRIPTION
The previous minimum version was a beta release (`black` only had beta releases at the time). This causes `pip` to install pre-releases by default. Changing to a stable (non-beta) minimum ensures that pip will only install stable releases by default.