### PR TITLE
Disable use-dict-literal pylint check

### DIFF
--- a/nengo_bones/templates/setup.cfg.template
+++ b/nengo_bones/templates/setup.cfg.template
@@ -148,6 +148,7 @@ disable =
     unsubscriptable-object,
     unsupported-assignment-operation,
     unused-argument,
+    use-dict-literal,
     {% for disable in pylint.disable %}
     {{ disable }},
     {% endfor %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,6 +103,7 @@ disable =
     unsubscriptable-object,
     unsupported-assignment-operation,
     unused-argument,
+    use-dict-literal,
 
 [pylint.imports]
 known-third-party =


### PR DESCRIPTION
Latest pylint release added this check, but I think there are plenty of situations where `dict()` is preferable for readability (e.g. long lists of kwargs).
