### PR TITLE
Mark dev version line as uncovered

### DIFF
--- a/nengo_bones/templates/pkg/version.py.template
+++ b/nengo_bones/templates/pkg/version.py.template
@@ -31,6 +31,6 @@ dev = {% if release %}None{% else %}0{% endif %}
 # (since this file is parsed in setup.py, before python_requires is applied)
 version = ".".join(str(v) for v in version_info)
 if dev is not None:
-    version += ".dev%d" % dev
+    version += ".dev%d" % dev  # pragma: no cover
 
 copyright = "Copyright (c) {{ copyright_start }}-{{ copyright_end }} {{ author }}"

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -23,6 +23,6 @@ dev = 0
 # (since this file is parsed in setup.py, before python_requires is applied)
 version = ".".join(str(v) for v in version_info)
 if dev is not None:
-    version += ".dev%d" % dev
+    version += ".dev%d" % dev  # pragma: no cover
 
 copyright = "Copyright (c) 2018-2023 Applied Brain Research"


### PR DESCRIPTION
Without this the coverage shows up as red on release builds, which isn't the end of the world but is a bit irritating.