### PR TITLE
Use python -m pip to upgrade pip

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -23,5 +23,5 @@ runs:
     - name: Update pip
       shell: bash
       run: |
-        pip install pip wheel --upgrade
+        python -m pip install pip wheel --upgrade
         pip --version


### PR DESCRIPTION
Windows requires this because it disallows the pip.exe process to modify pip.exe. This is currently blocking [pytest-plt](https://github.com/nengo/pytest-plt/actions/runs/4128287722/jobs/7132546087) from passing CI.

People recommend doing this everywhere that we use pip, but that would change a huge number of lines that are, as far as we can tell, working correctly right now.