### PR TITLE
Avoid docformatter 1.6

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -124,7 +124,7 @@ setup_py:
     - black>=22.1.0
     - click>=7.0
     - codespell>=2.0.0
-    - docformatter>=1.5.0,!=1.5.1
+    - docformatter==1.5.0
     - flake8>=3.7.7
     - jinja2>=2.11
     - jupyter>=1.0.0

--- a/docs/examples/configuration.ipynb
+++ b/docs/examples/configuration.ipynb
@@ -575,7 +575,7 @@
     "The `flake8` section has two options:\n",
     "\n",
     "- `exclude`: a list of filename patterns to be ignored\n",
-    "- `ignore`: a list of rules to be ignored; see https://lintlyci.github.io/Flake8Rules/\n",
+    "- `ignore`: a list of rules to be ignored; see https://www.flake8rules.com/\n",
     "  for a full list."
    ]
   },

--- a/nengo_bones/templates/static.sh.template
+++ b/nengo_bones/templates/static.sh.template
@@ -18,7 +18,7 @@ shopt -s globstar
         "mypy>=0.991" \
         {% endif %}
         "isort>=5.10.1" \
-        "docformatter>=1.5.0,!=1.5.1"
+        "docformatter==1.5.0"
 {% endblock %}
 
 {% block script %}

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -11,7 +11,7 @@ unless the code base represents a release version. Release versions are git
 tagged with the version.
 """
 
-version_info = (23, 2, 14)  # bones: ignore
+version_info = (23, 4, 4)  # bones: ignore
 
 name = "nengo-bones"
 dev = 0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_req = [
     "black>=22.1.0",
     "click>=7.0",
     "codespell>=2.0.0",
-    "docformatter>=1.5.0,!=1.5.1",
+    "docformatter==1.5.0",
     "flake8>=3.7.7",
     "jinja2>=2.11",
     "jupyter>=1.0.0",


### PR DESCRIPTION
It introduces formatting changes that are incompatible with pep8 (see https://github.com/PyCQA/docformatter/issues/161).
