### PR TITLE
Switch to worksteal xdist distribution method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
           - script: test-coverage
             test_local_var: test local var val
             test_args: --test-arg
-            python: "3.6"
+            python: "3.8"
             runs-on: ubuntu-20.04
-            coverage-name: test-coverage-3.6
+            coverage-name: test-coverage-oldest
           - script: test-nengo
             test_local_var: test local var val
             test_args: --test-arg
-            python: "3.9"
+            python: "3.11"
       fail-fast: false
     runs-on: ${{ matrix.runs-on || 'ubuntu-latest' }}
     env:
@@ -75,7 +75,7 @@ jobs:
       - uses: ./action-checkout/actions/setup
         with:
           path: nengo-bones
-          python-version: ${{ matrix.python || '3.7' }}
+          python-version: ${{ matrix.python || '3.9' }}
       - uses: ./action-checkout/actions/generate-and-check
         with:
           path: nengo-bones

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -141,10 +141,10 @@ setup_py:
     - "Operating System :: Microsoft :: Windows"
     - "Operating System :: POSIX :: Linux"
     - "Programming Language :: Python"
-    - "Programming Language :: Python :: 3.6"
-    - "Programming Language :: Python :: 3.7"
     - "Programming Language :: Python :: 3.8"
     - "Programming Language :: Python :: 3.9"
+    - "Programming Language :: Python :: 3.10"
+    - "Programming Language :: Python :: 3.11"
     - "Topic :: Software Development"
 
 setup_cfg:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Release History
 **Removed**
 
 - Removed codecov support. (`#178`_)
+- Dropped support for Python 3.6 and 3.7. (`#186`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Release History
 
 - Updated minimum version of dependencies in CI scripts. (`#178`_)
 - Switched to ``micromamba`` instead of ``miniconda`` for remote environments. (`#179`_)
+- Tests now default to using the ``worksteal`` xdist option, with 3 workers. (`#186`_)
 
 **Removed**
 
@@ -44,6 +45,7 @@ Release History
 .. _#178: https://github.com/nengo/nengo-bones/pull/178
 .. _#179: https://github.com/nengo/nengo-bones/pull/179
 .. _#183: https://github.com/nengo/nengo-bones/pull/183
+.. _#186: https://github.com/nengo/nengo-bones/pull/186
 
 22.11.15 (November 15, 2022)
 ============================

--- a/docs/examples/configuration.ipynb
+++ b/docs/examples/configuration.ipynb
@@ -94,7 +94,7 @@
     "  current year).\n",
     "- `copyright_end`: The last year work was done on the project (defaults to current\n",
     "  year).\n",
-    "- `min_python`: Minimum Python version (defaults to \"3.6\").\n",
+    "- `min_python`: Minimum Python version (defaults to \"3.8\").\n",
     "- `main_branch`: Main `git` branch (defaults to `\"master\"`)."
    ]
   },

--- a/nengo_bones/config.py
+++ b/nengo_bones/config.py
@@ -72,7 +72,7 @@ def fill_defaults(config):  # noqa: C901
     config.setdefault("author_email", "info@appliedbrainresearch.com")
     config.setdefault("copyright_start", datetime.datetime.now().year)
     config.setdefault("copyright_end", datetime.datetime.now().year)
-    config.setdefault("min_python", "3.6")
+    config.setdefault("min_python", "3.8")
     config.setdefault("main_branch", "master")
     config.setdefault("license", "proprietary")
 

--- a/nengo_bones/templates/test.sh.template
+++ b/nengo_bones/templates/test.sh.template
@@ -4,7 +4,7 @@
 {{ super() }}
     {# TODO: switch to templating requirements in setup.py, then remove these #}
     exe pip install "pytest>=7.0.0"
-    exe pip install "pytest-xdist>=3.0.0"
+    exe pip install "pytest-xdist>=3.2.0"
     {% if coverage %}
     exe pip install "pytest-cov>=4.0.0"
     {% endif %}
@@ -13,10 +13,10 @@
 
 {% block script %}
     # shellcheck disable=SC2086
-    exe pytest {{ pkg_name }} -v -n 2 --color=yes --durations 20 {%- if coverage %} --cov={{ pkg_name }} --cov-report=term-missing{%- endif %} $TEST_ARGS
+    exe pytest {{ pkg_name }} -v -n 3 --dist worksteal --color=yes --durations 20 {%- if coverage %} --cov={{ pkg_name }} --cov-report=term-missing{%- endif %} $TEST_ARGS
 
     {% if nengo_tests %}
     # shellcheck disable=SC2086
-    exe pytest --pyargs nengo -v -n 2 --color=yes --durations 20 {%- if coverage %} --cov={{ pkg_name }} --cov-append --cov-report=term-missing{%- endif %} $TEST_ARGS
+    exe pytest --pyargs nengo -v -n 3 --dist worksteal --color=yes --durations 20 {%- if coverage %} --cov={{ pkg_name }} --cov-append --cov-report=term-missing{%- endif %} $TEST_ARGS
     {% endif %}
 {% endblock %}

--- a/nengo_bones/tests/test_config.py
+++ b/nengo_bones/tests/test_config.py
@@ -99,7 +99,7 @@ def test_load_config(tmp_path):
         "project_name": "Dummy",
         "pkg_name": "dummy",
         "repo_name": "abr/dummy",
-        "min_python": "3.6",
+        "min_python": "3.8",
         "main_branch": "master",
         "author": "A Dummy",
         "author_email": "dummy@dummy.com",
@@ -111,7 +111,7 @@ def test_load_config(tmp_path):
         ],
         "setup_py": {
             "license_string": "Proprietary",
-            "python_requires": ">=3.6",
+            "python_requires": ">=3.8",
             "include_package_data": False,
             "url": "https://www.appliedbrainresearch.com/dummy",
             "classifiers": ["License :: Other/Proprietary License"],

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -11,7 +11,7 @@ unless the code base represents a release version. Release versions are git
 tagged with the version.
 """
 
-version_info = (23, 4, 19)  # bones: ignore
+version_info = (23, 5, 15)  # bones: ignore
 
 name = "nengo-bones"
 dev = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = ["setuptools<64", "wheel"]
 
 [tool.black]
-target-version = ['py36']
+target-version = ['py38']
 force_exclude = '''
 (
     tests/ignoreme/ignoreme.py

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "optional": optional_req,
         "tests": tests_req,
     },
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     entry_points={
         "console_scripts": [
             "bones=nengo_bones.scripts.base:bones",
@@ -80,8 +80,8 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Topic :: Software Development",


### PR DESCRIPTION
This should be a generic improvement to test speed across the board. It is possible that the change to 3 workers may cause some tests suites to fail, if they have tests that had undiscovered issues with parallelization.