### PR TITLE
Skip pypirc checks if file does not exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Release History
 - Updated minimum version of dependencies in CI scripts. (`#178`_)
 - Switched to ``micromamba`` instead of ``miniconda`` for remote environments. (`#179`_)
 - Tests now default to using the ``worksteal`` xdist option, with 3 workers. (`#186`_)
+- Modified ``check-deploy`` to skip checks when no ``.pypirc`` file present. (`#187`_)
 
 **Removed**
 
@@ -47,6 +48,7 @@ Release History
 .. _#179: https://github.com/nengo/nengo-bones/pull/179
 .. _#183: https://github.com/nengo/nengo-bones/pull/183
 .. _#186: https://github.com/nengo/nengo-bones/pull/186
+.. _#187: https://github.com/nengo/nengo-bones/pull/187
 
 22.11.15 (November 15, 2022)
 ============================

--- a/nengo_bones/scripts/check_deploy.py
+++ b/nengo_bones/scripts/check_deploy.py
@@ -56,10 +56,8 @@ def main(conf_file):
         f"Commit subject should be 'Release v{version.version}'",
     )
 
-    check(
-        pypirc.exists(),
-        "Cannot find ~/.pypirc. Make one to store PyPI credentials.",
-    )
+    if not pypirc.exists():
+        click.echo("Cannot find ~/.pypirc. Make one to store PyPI credentials.")
 
     changelog = Path(root_dir) / "CHANGES.rst"
     if changelog.exists():
@@ -74,7 +72,8 @@ def main(conf_file):
             f"Version '{version.version}' does not match git branch '{git_branch}'",
         )
         check(
-            "[testpypi]\n" in pypirc_text, "[testpypi] section not found in ~/.pypirc"
+            not pypirc.exists() or "[testpypi]\n" in pypirc_text,
+            "[testpypi] section not found in ~/.pypirc",
         )
 
     if release:
@@ -82,7 +81,10 @@ def main(conf_file):
             f"v{version.version}" == git_tag,
             f"Version '{version.version}' does not match git tag '{git_tag}'",
         )
-        check("[pypi]\n" in pypirc_text, "[pypi] section not found in ~/.pypirc")
+        check(
+            not pypirc.exists() or "[pypi]\n" in pypirc_text,
+            "[pypi] section not found in ~/.pypirc",
+        )
 
     output = subprocess.run(
         ["check-manifest", root_dir],

--- a/nengo_bones/tests/test_check_deploy.py
+++ b/nengo_bones/tests/test_check_deploy.py
@@ -128,11 +128,24 @@ def test_subject(tmp_path, monkeypatch):
     assert "Commit subject should be 'Release v1.2.3'" in result.output
 
 
-def test_pypirc(tmp_path, monkeypatch):
+def test_no_pypirc(tmp_path, monkeypatch):
     _monkeypatch(tmp_path, monkeypatch)
     result = _write_repo_and_check(tmp_path, pypirc=False)
-    assert_exit(result, 1)
+    assert_exit(result, 0)
     assert "Cannot find ~/.pypirc. Make one" in result.output
+
+
+def test_pypirc_exists(tmp_path, monkeypatch):
+    _monkeypatch(tmp_path, monkeypatch)
+    result = _write_repo_and_check(tmp_path, pypirc=True)
+    assert_exit(result, 0)
+
+
+def test_pypirc_invalid(tmp_path, monkeypatch):
+    _monkeypatch(tmp_path, monkeypatch)
+    write_file(tmp_path=tmp_path, filename=".pypirc", contents="")
+    result = _write_repo_and_check(tmp_path, pypirc=False)
+    assert_exit(result, 1)
     assert "[pypi] section not found in ~/.pypirc" in result.output
     assert "[testpypi] section not found in ~/.pypirc" in result.output
 


### PR DESCRIPTION
**Motivation and context:**
We would like to run `bones check-deploy` on repos that do not have a pypirc file, such as nengo-edge-server.

**Interactions with other PRs:**
Should not interact with other changes

**How has this been tested?**
I'm unsure how this should be tested.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)


**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [ ] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
