### PR TITLE
Don't include setup.py hash in cache key

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 NengoBones license
 ******************
 
-Copyright (c) 2018-2023 Applied Brain Research
+Copyright (c) 2018-2024 Applied Brain Research
 
 **ABR License**
 

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -24,6 +24,4 @@ runs:
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        key: ${{ runner.os }}-pip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,6 @@ extensions = [
     "sphinx.ext.todo",
     "nbsphinx",
     "nengo_sphinx_theme",
-    "nengo_sphinx_theme.ext.backoff",
     "nengo_sphinx_theme.ext.redirects",
     "nengo_sphinx_theme.ext.sourcelinks",
     "notfound.extension",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ suppress_warnings = ["image.nonlocal_uri"]
 
 project = "NengoBones"
 authors = "Applied Brain Research"
-copyright = "2018-2023 Applied Brain Research"
+copyright = "2018-2024 Applied Brain Research"
 version = ".".join(nengo_bones.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_bones.__version__  # Full version, with tags
 

--- a/nengo_bones/templates/docs/conf.py.template
+++ b/nengo_bones/templates/docs/conf.py.template
@@ -16,7 +16,6 @@ extensions = [
     "sphinx.ext.todo",
     "nbsphinx",
     "nengo_sphinx_theme",
-    "nengo_sphinx_theme.ext.backoff",
     {% if html_redirects %}
     "nengo_sphinx_theme.ext.redirects",
     {% endif %}

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -11,7 +11,7 @@ unless the code base represents a release version. Release versions are git
 tagged with the version.
 """
 
-version_info = (23, 11, 7)  # bones: ignore
+version_info = (24, 1, 15)  # bones: ignore
 
 name = "nengo-bones"
 dev = 0
@@ -22,4 +22,4 @@ version = ".".join(str(v) for v in version_info)
 if dev is not None:
     version += ".dev%d" % dev  # pragma: no cover
 
-copyright = "Copyright (c) 2018-2023 Applied Brain Research"
+copyright = "Copyright (c) 2018-2024 Applied Brain Research"


### PR DESCRIPTION
Having separate caches for different versions of setup.py increases the github storage usage, and is unlikely to provide much practical benefit.