### PR TITLE
Update actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./actions/setup
         with:
           python-version: "3.11"
@@ -75,7 +75,7 @@ jobs:
       JOB_SUFFIX: ${{ matrix.remote-id }}
       GH_TOKEN: ${{ secrets.PUBLIC_GH_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: action-checkout
       - uses: ./action-checkout/actions/setup
@@ -93,7 +93,7 @@ jobs:
         with:
           name: ${{ matrix.script }}
           path: nengo-bones
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() && matrix.coverage-name }}
         with:
           name: coverage-${{ matrix.coverage-name }}
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./actions/coverage-report
   auto-update:
     needs:
@@ -116,7 +116,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.PUBLIC_GH_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./actions/setup
         with:
           python-version: "3.11"
@@ -136,7 +136,7 @@ jobs:
       - name: Write .pypirc to file
         run: |
           echo '${{ secrets.PYPIRC_FILE }}' > ~/.pypirc
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./actions/setup
         with:
           python-version: "3.10"

--- a/actions/coverage-report/action.yml
+++ b/actions/coverage-report/action.yml
@@ -8,15 +8,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install coverage
       shell: bash -el {0}
       run: |
         pip install coverage
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download
     - name: Combine coverage and generate report
       shell: bash -el {0}
@@ -24,7 +24,7 @@ runs:
         coverage combine $(find ${{ steps.download.outputs.download-path }} -type f -name ".coverage")
         coverage html
         coverage report --show-missing --fail-under=${{ inputs.min-coverage }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: coverage-report

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: ${{ inputs.path }}
     - uses: mamba-org/setup-micromamba@v1
@@ -21,7 +21,7 @@ runs:
         environment-name: ci
         cache-downloads: true
         generate-run-shell: false
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip

--- a/nengo_bones/scripts/check_notice.py
+++ b/nengo_bones/scripts/check_notice.py
@@ -1,6 +1,5 @@
 """Checks that license text is added to all .py files."""
 
-
 import click
 
 from nengo_bones.templates import add_notice


### PR DESCRIPTION
Github is deprecating support for Node 16 (which was previously used by most of the github actions), so we need to update to the latest versions (which use Node 20).