### PR TITLE
Remove analytics tracking from docs template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ Release History
 - Removed codecov support. (`#178`_)
 - Dropped support for Python 3.6 and 3.7. (`#186`_)
 - Removed ``.pre-commit-config.yaml`` from templated files. (`#191`_)
+- Removed the analytics tracking code in generated ``docs/conf.py`` files.
 
 **Fixed**
 

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 NengoBones license
 ******************
 
-Copyright (c) 2018-2025 Applied Brain Research
+Copyright (c) 2018-2026 Applied Brain Research
 
 **ABR License**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ suppress_warnings = ["image.nonlocal_uri"]
 
 project = "NengoBones"
 authors = "Applied Brain Research"
-copyright = "2018-2025 Applied Brain Research"
+copyright = "2018-2026 Applied Brain Research"
 version = ".".join(nengo_bones.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_bones.__version__  # Full version, with tags
 
@@ -96,36 +96,6 @@ html_favicon = str(pathlib.Path("_static", "favicon.ico"))
 html_theme_options = {
     "nengo_logo": "general-full-light.svg",
     "nengo_logo_color": "#a8acaf",
-    "analytics": """
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-GT8XEDLTMJ"></script>
-        <script>
-         window.dataLayer = window.dataLayer || [];
-         function gtag(){dataLayer.push(arguments);}
-         gtag('js', new Date());
-         gtag('config', 'G-GT8XEDLTMJ');
-        </script>
-        <!-- End Google tag (gtag.js) -->
-        <!-- Matomo -->
-        <script>
-         var _paq = window._paq = window._paq || [];
-         _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-         _paq.push(["setCookieDomain", "*.appliedbrainresearch.com"]);
-         _paq.push(["setDomains", ["*.appliedbrainresearch.com","*.edge.nengo.ai","*.forum.nengo.ai","*.nengo.ai"]]);
-         _paq.push(["enableCrossDomainLinking"]);
-         _paq.push(["setDoNotTrack", true]);
-         _paq.push(['trackPageView']);
-         _paq.push(['enableLinkTracking']);
-         (function() {
-           var u="https://appliedbrainresearch.matomo.cloud/";
-           _paq.push(['setTrackerUrl', u+'matomo.php']);
-           _paq.push(['setSiteId', '3']);
-           var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-           g.async=true; g.src='//cdn.matomo.cloud/appliedbrainresearch.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-         })();
-        </script>
-        <!-- End Matomo Code -->
-    """,
 }
 html_redirects = [
     ("changelog.html", "changes.html"),

--- a/nengo_bones/templates/docs/conf.py.template
+++ b/nengo_bones/templates/docs/conf.py.template
@@ -120,38 +120,7 @@ html_favicon = str(pathlib.Path("_static", "favicon.ico"))
 html_theme_options = {
     "nengo_logo": "{{ nengo_logo }}",
     "nengo_logo_color": "{{ nengo_logo_color }}",
-    {% block analytics %}
-    "analytics": """
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-GT8XEDLTMJ"></script>
-        <script>
-         window.dataLayer = window.dataLayer || [];
-         function gtag(){dataLayer.push(arguments);}
-         gtag('js', new Date());
-         gtag('config', 'G-GT8XEDLTMJ');
-        </script>
-        <!-- End Google tag (gtag.js) -->
-        <!-- Matomo -->
-        <script>
-         var _paq = window._paq = window._paq || [];
-         _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-         _paq.push(["setCookieDomain", "*.appliedbrainresearch.com"]);
-         _paq.push(["setDomains", ["*.appliedbrainresearch.com","*.edge.nengo.ai","*.forum.nengo.ai","*.nengo.ai"]]);
-         _paq.push(["enableCrossDomainLinking"]);
-         _paq.push(["setDoNotTrack", true]);
-         _paq.push(['trackPageView']);
-         _paq.push(['enableLinkTracking']);
-         (function() {
-           var u="https://appliedbrainresearch.matomo.cloud/";
-           _paq.push(['setTrackerUrl', u+'matomo.php']);
-           _paq.push(['setSiteId', '3']);
-           var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-           g.async=true; g.src='//cdn.matomo.cloud/appliedbrainresearch.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-         })();
-        </script>
-        <!-- End Matomo Code -->
-    """,
-    {% endblock %}
+    {% block analytics %}{% endblock %}
     {% if one_page %}
     "one_page": True
     {% endif %}

--- a/nengo_bones/version.py
+++ b/nengo_bones/version.py
@@ -22,4 +22,4 @@ version = ".".join(str(v) for v in version_info)
 if dev is not None:
     version += ".dev%d" % dev  # pragma: no cover
 
-copyright = "Copyright (c) 2018-2025 Applied Brain Research"
+copyright = "Copyright (c) 2018-2026 Applied Brain Research"


### PR DESCRIPTION
Generated docs/conf.py files no longer inject Google Analytics and Matomo tracking into Nengo documentation sites.